### PR TITLE
perf: optimize token usage — merge 111→58 tools, trim docstrings 75%

### DIFF
--- a/.claude/commands/pull.md
+++ b/.claude/commands/pull.md
@@ -18,7 +18,7 @@ git status
 ```bash
 git fetch origin
 git log --oneline HEAD..origin/master  # 새 커밋 확인
-git pull origin master
+git pull myfork master
 ```
 
 ### 3단계: GCP에서 로컬 전용 파일 역동기화
@@ -40,7 +40,7 @@ gcloud compute scp ohmil@sanjuk-project:/home/ohmil/.claude/projects/-home-ohmil
 ### 4단계: GCP VM 코드도 최신으로
 
 ```bash
-gcloud compute ssh sanjuk-project --zone=us-central1-b --command="cd ~/3dsmax-mcp && git pull origin master 2>&1"
+gcloud compute ssh sanjuk-project --zone=us-central1-b --command="cd ~/3dsmax-mcp && git pull myfork master 2>&1"
 ```
 
 ### 5단계: 변경사항 비교 보고

--- a/.claude/commands/pull.md
+++ b/.claude/commands/pull.md
@@ -18,7 +18,7 @@ git status
 ```bash
 git fetch origin
 git log --oneline HEAD..origin/master  # 새 커밋 확인
-git pull myfork master
+git pull origin master
 ```
 
 ### 3단계: GCP에서 로컬 전용 파일 역동기화
@@ -40,7 +40,7 @@ gcloud compute scp ohmil@sanjuk-project:/home/ohmil/.claude/projects/-home-ohmil
 ### 4단계: GCP VM 코드도 최신으로
 
 ```bash
-gcloud compute ssh sanjuk-project --zone=us-central1-b --command="cd ~/3dsmax-mcp && git pull myfork master 2>&1"
+gcloud compute ssh sanjuk-project --zone=us-central1-b --command="cd ~/3dsmax-mcp && git pull origin master 2>&1"
 ```
 
 ### 5단계: 변경사항 비교 보고

--- a/.claude/commands/pull.md
+++ b/.claude/commands/pull.md
@@ -1,0 +1,51 @@
+# 풀 — GitHub/GCP → 로컬 전체 동기화
+
+GitHub와 GCP의 최신 데이터를 비교하여 로컬에 동기화합니다.
+
+## 실행 순서
+
+### 1단계: 로컬 상태 확인
+
+```bash
+git status
+```
+
+- 커밋되지 않은 변경사항이 있으면 경고 후 stash 제안
+- 클린 상태면 진행
+
+### 2단계: GitHub에서 풀
+
+```bash
+git fetch origin
+git log --oneline HEAD..origin/master  # 새 커밋 확인
+git pull origin master
+```
+
+### 3단계: GCP에서 로컬 전용 파일 역동기화
+
+GCP에서 변경되었을 수 있는 파일들을 로컬로 복사:
+
+**메모리 파일 (GCP 모바일 세션에서 업데이트되었을 수 있음):**
+```bash
+# GCP 메모리 → 로컬 메모리 (비교 후 최신만)
+gcloud compute ssh sanjuk-project --zone=us-central1-b --command="ls -la ~/.claude/projects/-home-ohmil-3dsmax-mcp/memory/ 2>/dev/null"
+```
+
+각 파일의 수정 시간을 비교:
+```bash
+# GCP 파일이 더 최신이면 복사
+gcloud compute scp ohmil@sanjuk-project:/home/ohmil/.claude/projects/-home-ohmil-3dsmax-mcp/memory/* ~/.claude/projects/C--dev-3dsmax-mcp/memory/ --zone=us-central1-b
+```
+
+### 4단계: GCP VM 코드도 최신으로
+
+```bash
+gcloud compute ssh sanjuk-project --zone=us-central1-b --command="cd ~/3dsmax-mcp && git pull origin master 2>&1"
+```
+
+### 5단계: 변경사항 비교 보고
+
+동기화 완료 후 요약:
+- GitHub: 새로 받은 커밋 목록
+- GCP → 로컬: 업데이트된 메모리 파일
+- 충돌: 있으면 표시 및 해결 제안

--- a/.claude/commands/push.md
+++ b/.claude/commands/push.md
@@ -18,13 +18,14 @@ git diff --stat
 ### 2단계: GitHub에 푸시
 
 ```bash
-git push origin master
+git push myfork master
 ```
 
 ### 3단계: GCP VM 코드 동기화
 
 ```bash
 gcloud compute ssh sanjuk-project --zone=us-central1-b --command="cd ~/3dsmax-mcp && git pull origin master 2>&1"
+# Note: GCP remote is set to kanzaka110/3dsmax-mcp (the fork)
 ```
 
 ### 4단계: GCP VM에 로컬 전용 파일 동기화

--- a/.claude/commands/push.md
+++ b/.claude/commands/push.md
@@ -1,0 +1,72 @@
+# 푸시 — 로컬 → GitHub/GCP/모바일 전체 동기화
+
+로컬의 모든 최신 데이터를 GitHub, GCP VM, 연결된 모바일까지 동기화합니다.
+
+## 실행 순서
+
+### 1단계: 로컬 변경사항 확인 및 커밋
+
+```bash
+git status
+git diff --stat
+```
+
+- 변경된 파일이 있으면 자동 커밋 (conventional commit 형식)
+- 민감 파일(.env, credentials 등) 제외
+- 변경 없으면 이 단계 스킵
+
+### 2단계: GitHub에 푸시
+
+```bash
+git push origin master
+```
+
+### 3단계: GCP VM 코드 동기화
+
+```bash
+gcloud compute ssh sanjuk-project --zone=us-central1-b --command="cd ~/3dsmax-mcp && git pull origin master 2>&1"
+```
+
+### 4단계: GCP VM에 로컬 전용 파일 동기화
+
+로컬에만 있는 파일들(gitignore 대상)을 GCP에 복사:
+
+**스킬 파일 (빌드된 .claude/skills/):**
+```bash
+# skills/ 디렉토리의 최신 파일을 GCP에 동기화
+gcloud compute scp --recurse skills/3dsmax-mcp-dev/ ohmil@sanjuk-project:/home/ohmil/3dsmax-mcp/skills/3dsmax-mcp-dev/ --zone=us-central1-b
+```
+
+**글로벌 rules:**
+```bash
+for f in ~/.claude/rules/common/*.md; do
+  gcloud compute scp "$f" ohmil@sanjuk-project:/home/ohmil/.claude/rules/common/$(basename "$f") --zone=us-central1-b
+done
+```
+
+**메모리 파일:**
+```bash
+# 로컬 메모리 → GCP 프로젝트 메모리
+gcloud compute ssh sanjuk-project --zone=us-central1-b --command="mkdir -p ~/.claude/projects/-home-ohmil-3dsmax-mcp/memory"
+for f in ~/.claude/projects/C--dev-3dsmax-mcp/memory/*; do
+  gcloud compute scp "$f" ohmil@sanjuk-project:/home/ohmil/.claude/projects/-home-ohmil-3dsmax-mcp/memory/$(basename "$f") --zone=us-central1-b
+done
+```
+
+### 5단계: GCP remote-control 세션 확인
+
+```bash
+gcloud compute ssh sanjuk-project --zone=us-central1-b --command="tmux capture-pane -t max3d -p 2>&1 | tail -5"
+```
+
+- remote-control이 죽었으면 재시작:
+```bash
+gcloud compute ssh sanjuk-project --zone=us-central1-b --command="tmux send-keys -t max3d 'claude remote-control --name 3dsmax-mcp-GCP' Enter"
+```
+
+### 6단계: 결과 보고
+
+모든 단계 완료 후 요약:
+- Git: 커밋/푸시 결과
+- GCP: 동기화된 파일 수
+- 모바일: remote-control 상태 (모바일은 GCP 동기화 시 자동 반영)

--- a/.claude/commands/push.md
+++ b/.claude/commands/push.md
@@ -18,7 +18,7 @@ git diff --stat
 ### 2단계: GitHub에 푸시
 
 ```bash
-git push myfork master
+git push origin master
 ```
 
 ### 3단계: GCP VM 코드 동기화

--- a/scripts/run_live_plugin_learning.py
+++ b/scripts/run_live_plugin_learning.py
@@ -8,7 +8,7 @@ import sys
 from typing import Any
 
 from src.tools.bridge import get_bridge_status
-from src.tools.plugins import discover_plugin_surface, get_plugin_manifest, inspect_plugin_class, inspect_plugin_instance
+from src.tools.plugins import _discover_surface, _get_manifest, _inspect_class, _inspect_instance
 from src.tools.railclone import get_railclone_style_graph
 
 
@@ -94,7 +94,7 @@ def main() -> int:
 
     step = "discover_plugin_surface"
     try:
-        discovered = _load_json(discover_plugin_surface(plugin_name=args.plugin))
+        discovered = _load_json(_discover_surface(plugin_name=args.plugin))
         failed |= not _expect(bool(discovered.get("installed")), step, "plugin is not reported installed")
         failed |= not _expect(
             _normalize(str(discovered.get("plugin", ""))) == normalized_plugin,
@@ -108,7 +108,7 @@ def main() -> int:
 
     step = "get_plugin_manifest"
     try:
-        manifest = _load_json(get_plugin_manifest(args.plugin))
+        manifest = _load_json(_get_manifest(args.plugin))
         failed |= not _expect(bool(manifest.get("installed")), step, "manifest says plugin is not installed")
         failed |= not _expect(
             _normalize(str(manifest.get("plugin", ""))) == normalized_plugin,
@@ -125,7 +125,7 @@ def main() -> int:
     class_name = _choose_class(manifest, args.class_name)
     step = "inspect_plugin_class"
     try:
-        inspected_class = _load_json(inspect_plugin_class(class_name))
+        inspected_class = _load_json(_inspect_class(class_name))
         failed |= not _expect("error" not in inspected_class, step, inspected_class.get("error", "unknown inspect_plugin_class error"))
         failed |= not _expect(inspected_class.get("class") == class_name, step, f"returned class {inspected_class.get('class')!r}")
         failed |= not _expect(isinstance(inspected_class.get("methods"), list), step, "methods is not a list")
@@ -136,7 +136,7 @@ def main() -> int:
 
     step = "inspect_plugin_instance"
     try:
-        inspected_instance = _load_json(inspect_plugin_instance(args.object, detail="normal"))
+        inspected_instance = _load_json(_inspect_instance(args.object, detail="normal"))
         failed |= not _expect(
             _normalize(str(inspected_instance.get("primaryPlugin", ""))) == normalized_plugin,
             step,

--- a/skills/3dsmax-mcp-dev/SKILL.md
+++ b/skills/3dsmax-mcp-dev/SKILL.md
@@ -262,7 +262,65 @@ If you catch yourself writing MAXScript that a tool already handles, stop and us
 - `introspect_class` is blocked for OSLMap (663K+ output) — always use `introspect_osl` instead
 - After creation, wire via `set_material_property`
 
-## 9. C++ SDK Pitfalls
+## 9. Python / pymxs Integration
+
+### Architecture
+- `pymxs` wraps the MAXScript engine, NOT the C++ SDK directly
+- MaxPlus was discontinued in 3ds Max 2022 — pymxs is the only supported Python module
+- To use pymxs effectively, you **must understand MAXScript** — same API surface
+
+### When to Use pymxs (over MAXScript)
+- Pipeline tools that work across DCCs (Maya, Blender, Houdini)
+- When you need third-party libraries (NumPy, requests, PIL, JSON)
+- Modern OOP with proper module/import system and unit testing
+- Qt UI via PySide2 (superior to .NET WinForms for complex UIs)
+
+### When to Use MAXScript (over pymxs)
+- **Scripted plugins** (geometry, modifiers, materials, utilities) — **pymxs CANNOT create these**
+- Script controllers and expression controllers
+- When mesh operation performance matters (**pymxs is ~10x slower** for mesh ops)
+- Small daily-use tools and quick automation
+
+### pymxs Limitations
+- **Undo not supported**: pymxs operations are NOT recorded by the undo system
+- **Not thread-safe**: always runs in main thread
+- **Array indexing auto-converts**: Python 0-based ↔ MAXScript 1-based (transparent but can confuse)
+- **Sparse documentation** compared to MAXScript docs
+- Cannot define scripted plugins, script controllers, or custom attributes from Python
+
+### Calling Between Languages
+```maxscript
+-- MAXScript → Python
+python.Execute "print('hello from python')"
+python.Execute "import pymxs; pymxs.runtime.Box()"
+
+-- Python → MAXScript
+import pymxs
+rt = pymxs.runtime
+rt.execute("Box width:10")
+rt.Box(width=10)  -- direct pymxs access
+```
+
+### Hybrid Pattern (Recommended)
+Write **library/pipeline modules in Python**, use **MAXScript for plugin definitions and Max-specific glue**.
+
+### pymxs Stubs for IDE
+Install `friedererdmann/pymxs_stubs` (GitHub) for VS Code/PyCharm autocomplete and type checking.
+
+## 10. Version-Specific Breaking Changes
+
+### 3ds Max 2026
+- **.NET Framework 4.8.1 → .NET Core 8**: `CSharpCodeProvider.CompileAssemblyFromSource` removed. Use new `CSharpCompilationHelper.Compile` static method instead
+- **MenuMan removed**: replaced with `CuiDynamicMenu`/`CuiMenu` API for custom menus
+- **New `kwargs` keyword**: pass Python function parameters from MAXScript
+- **Color management overhaul**: `ColorPipelineMgr` new, `iDisplayGamma` removed
+- **`Matrix3(1)` deprecated**: use `Matrix3()` default constructor
+- **`WStr::operator bool` deleted**: use `.data() && .data()[0]` checks
+
+### 3ds Max 2027
+- Improvements to `getMaxFileObjects` and `mergeMaxFile` — layer information querying and merging support added
+
+## 12. C++ SDK Pitfalls
 
 - `is_array()` / `is_string()` / `is_number_*()` / `is_boolean()` macro collision with MAXScript headers — use `.type() == json::value_t::array` / `::string` / `::number_float` / `::number_integer` / `::boolean` instead
 - `Matrix3(1)` deprecated in Max 2026 — use `Matrix3()` default
@@ -272,14 +330,14 @@ If you catch yourself writing MAXScript that a tool already handles, stop and us
 - `WStr::operator bool` deleted in Max 2026 — use `.data() && .data()[0]` checks
 - Native scene-delta baselines must be scoped per pipe client and cleared on scene reset/fetch; one process-global snapshot leaks across simultaneous agents and unrelated scenes.
 
-## 10. MAXScript Reference Files
+## 13. MAXScript Reference Files
 
 This skill includes bundled MAXScript reference files for writing correct MAXScript. Read the relevant file BEFORE writing MAXScript code for unfamiliar areas.
 
 | File | Covers |
 |------|--------|
 | `maxscript-core-syntax.md` | Variables, scope, types, operators, control flow, collections, strings |
-| `maxscript-common-patterns.md` | Undo blocks, animate blocks, callbacks, file I/O, performance |
+| `maxscript-common-patterns.md` | Undo, animate, callbacks, change handlers, node events, GC, file I/O, debugging, performance |
 | `maxscript-3dsmax-objects.md` | Node creation, transforms, hierarchy, properties, superclasses |
 | `maxscript-mesh-poly-ops.md` | Mesh/poly sub-object ops, vertex/edge/face manipulation |
 | `maxscript-materials-textures.md` | Material creation, texmap wiring, Standard/Physical/Arnold |
@@ -287,7 +345,7 @@ This skill includes bundled MAXScript reference files for writing correct MAXScr
 | `maxscript-rendering-cameras.md` | Render settings, cameras, environment, render elements |
 | `maxscript-splines-shapes.md` | Spline creation, knots, interpolation, shape booleans |
 | `maxscript-scripted-plugins.md` | Custom scripted geometry, modifiers, materials, utilities |
-| `maxscript-ui-rollouts.md` | Rollout UIs, dialogs, controls, event handlers |
+| `maxscript-ui-rollouts.md` | Rollout UIs, dialogs, controls, event handlers, WPF integration |
 
 **IMPORTANT:** Before writing any MAXScript, READ the relevant file. Do not guess syntax.
 
@@ -296,7 +354,7 @@ This skill includes bundled MAXScript reference files for writing correct MAXScr
 Read: skills/3dsmax-mcp-dev/maxscript-materials-textures.md
 ```
 
-## 11. Architecture
+## 14. Architecture
 
 ```
 Agent <-> FastMCP (Python/stdio) <-> Named Pipe <-> C++ GUP Plugin <-> 3ds Max SDK

--- a/skills/3dsmax-mcp-dev/maxscript-common-patterns.md
+++ b/skills/3dsmax-mcp-dev/maxscript-common-patterns.md
@@ -428,3 +428,187 @@ for i = 1 to 1000 while found do
 - **Assemblies cannot be unloaded** once loaded via `dotNet.loadAssembly`.
 - **Callbacks registered with functions cannot be persisted.** Only string-based callbacks support `persistent:true`.
 - **Always use `#noPrompt` with `resetMaxFile`** in batch scripts to avoid blocking save dialogs.
+- **DotNet lifetime control**: unreferenced .NET objects may not be collected by MAXScript GC. Use `dotNet.setLifetimeControl obj #dotnet` to let .NET manage the object's lifetime, or `#mxs` (default) for MAXScript-managed.
+- **Change handler `do` body runs in isolated context**: cannot reference local variables from surrounding scope. Store state in globals or struct members.
+- **Accumulated change handlers leak**: unmanaged `when` constructs persist and degrade performance. Always store the returned ChangeHandler value and call `deleteChangeHandler` to dismiss.
+- **Bitmap memory**: `close bm` after `openBitmap`/`renderMap` to release memory. Unclosed bitmaps accumulate. Use `freeSceneBitmaps()` to flush texture caches.
+
+## INI File I/O (Built-in)
+
+```maxscript
+-- Read
+val = getINISetting @"C:\config.ini" "Section" "Key"
+
+-- Write
+setINISetting @"C:\config.ini" "Section" "Key" "Value"
+
+-- Delete key
+delINISetting @"C:\config.ini" "Section" "Key"
+-- Delete section
+delINISetting @"C:\config.ini" "Section"
+
+-- List all sections
+getINISetting @"C:\config.ini"
+-- List all keys in a section
+getINISetting @"C:\config.ini" "Section"
+```
+
+Commonly used for tool configuration. Returns empty string `""` if key not found.
+
+## Change Handlers (when construct)
+
+Monitor object attribute changes:
+```maxscript
+-- Monitor transform changes
+local handler = when transform $Box001 changes val do (
+    format "Box moved to: %\n" $Box001.pos
+)
+
+-- Monitor multiple objects
+when geometry selection changes do (
+    format "Geometry changed on selection\n"
+)
+
+-- Monitor name changes
+when name $* changes do (
+    format "Something renamed\n"
+)
+
+-- Dismiss handler
+deleteChangeHandler handler
+```
+
+Monitorable attributes: `geometry`, `topology`, `names`, `transform`, `select`, `subobjectSelect`, `parameters`, `controller`.
+
+**handleAt parameter**: controls when callback fires:
+```maxscript
+-- Default: fires at unknown time (possibly mid-operation)
+when transform $Box001 changes do (...)
+
+-- Fire at redraw time (safer for UI updates)
+when transform $Box001 changes handleAt:#redrawViews do (...)
+```
+
+**Deletion monitoring:**
+```maxscript
+when $Box001 deleted obj do (
+    format "% was deleted\n" obj.name
+)
+```
+
+## Node Event System (3ds Max 2009+)
+
+More comprehensive than `when` constructs. Catches events that `when` misses (undo/redo, linking, layer changes).
+
+```maxscript
+fn myCallback evt nd = (
+    format "Event: % on nodes: %\n" evt nd
+)
+
+nec = NodeEventCallback mouseUp:true delay:200 \
+    added:myCallback \
+    deleted:myCallback \
+    nameChanged:myCallback \
+    geometryChanged:myCallback \
+    topologyChanged:myCallback \
+    materialChanged:myCallback \
+    wireColorChanged:myCallback \
+    selectionChanged:myCallback \
+    linkChanged:myCallback \
+    layerChanged:myCallback \
+    controllerChanged:myCallback \
+    hideChanged:myCallback \
+    freezeChanged:myCallback
+
+-- Disable/enable
+nec.enabled = false
+nec.enabled = true
+
+-- Cleanup (critical!)
+nec = undefined
+gc light:true
+```
+
+`mouseUp:true` delays firing until mouse release (prevents per-frame spam during dragging). `delay:` coalesces rapid events (ms).
+
+## Viewport Redraw Callbacks
+
+Draw custom overlays in viewports:
+```maxscript
+fn myRedrawCallback = (
+    gw.setTransform (matrix3 1)
+    gw.text [10,10,0] "Hello Viewport" color:yellow
+    gw.enlargeUpdateRect #whole
+    gw.updateScreen()
+)
+
+-- Register
+registerRedrawViewsCallback myRedrawCallback
+
+-- Unregister (ALWAYS clean up — leaks cause permanent lag)
+unRegisterRedrawViewsCallback myRedrawCallback
+```
+
+**Warning**: Heavy operations in redraw callbacks cause viewport lag. Keep callback functions minimal.
+
+## Garbage Collection Details
+
+```maxscript
+-- Full GC: frees all reclaimable values, FLUSHES UNDO BUFFER
+gc()
+
+-- Light GC: skips MAXWrapper values, preserves undo
+gc light:true
+
+-- Check heap usage
+heapSize     -- current heap allocation (bytes)
+heapFree     -- available heap (bytes)
+```
+
+**How automatic GC works:**
+1. Heap runs low → tries light GC first (preserves undo)
+2. If insufficient → full GC (flushes undo buffer)
+3. If still insufficient → expands heap
+
+**Rules:**
+- Use `gc light:true` in tools where undo preservation matters
+- Call `gc()` (full) to release locked file handles from errored scripts
+- Never rely on `gc light:true` to collect node references — they are MAXWrapper-derived
+- Heavy scripts should periodically `gc light:true` to prevent GC pauses at unpredictable moments
+
+## Debugging Techniques
+
+**MAXScript Debugger** (built-in):
+- Open via MAXScript menu → Debugger
+- Supports breakpoints, step-through, variable inspection
+- Manual breakpoint: insert `break()` in code
+- Examine locals, globals, and call stack while paused
+
+**Profiling with timeStamp:**
+```maxscript
+t1 = timeStamp()
+-- code to profile
+t2 = timeStamp()
+format "Elapsed: %ms\n" (t2 - t1)
+```
+
+**Runtime inspection:**
+```maxscript
+classOf obj             -- exact class
+superClassOf obj        -- superclass
+showProperties obj      -- list all properties
+showMethods obj         -- list all methods
+showInterfaces obj      -- list all interfaces
+isValidNode obj         -- check if node reference is still valid
+isProperty obj #name    -- check if property exists
+getMAXScriptHost()      -- determine execution context
+```
+
+**Error source info (3ds Max 2018+):**
+```maxscript
+try ( riskyOp() ) catch (
+    format "Error: %\n" (getCurrentException())
+    format "File: %\n" (getErrorSourceFileName())
+    format "Line: %\n" (getErrorSourceFileLine())
+)
+```

--- a/skills/3dsmax-mcp-dev/maxscript-ui-rollouts.md
+++ b/skills/3dsmax-mcp-dev/maxscript-ui-rollouts.md
@@ -479,3 +479,53 @@ Use `@` instead of inner `"` for strings inside `codeStr`. Pass `filter:on` when
 **Parent dialog to another:** `createDialog child pos:[200,200] parent:parentRollout.hwnd`
 
 **Resizable dialog:** `createDialog myRollout style:#(#style_titlebar, #style_border, #style_sysmenu, #style_resizing)`
+
+---
+
+## WPF Integration from MAXScript
+
+For complex UIs beyond rollouts and WinForms:
+
+```maxscript
+-- Load WPF assemblies
+dotNet.loadAssembly "PresentationFramework"
+dotNet.loadAssembly "PresentationCore"
+dotNet.loadAssembly "WindowsBase"
+
+-- Define XAML as string
+xamlStr = @"<Window xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    Title='My WPF Tool' Width='300' Height='200'>
+    <StackPanel Margin='10'>
+        <TextBlock Text='Hello WPF from MAXScript!' FontSize='16'/>
+        <Button x:Name='btnAction' Content='Do Something' Margin='0,10,0,0'/>
+    </StackPanel>
+</Window>"
+
+-- Parse XAML and create window
+reader = dotNetObject "System.IO.StringReader" xamlStr
+xmlReader = (dotNetClass "System.Xml.XmlReader").Create reader
+wpfWindow = (dotNetClass "System.Windows.Markup.XamlReader").Load xmlReader
+
+-- Parent to 3ds Max (critical for proper window management)
+maxHwnd = (dotNetClass "ManagedServices.AppSDK").GetMaxHWND()
+interopHelper = dotNetObject "System.Windows.Interop.WindowInteropHelper" wpfWindow
+interopHelper.Owner = maxHwnd
+
+-- Find named elements
+btn = wpfWindow.FindName "btnAction"
+
+-- Add event handlers
+fn onBtnClick s e = ( print "WPF button clicked!" )
+dotNet.addEventHandler btn "Click" onBtnClick
+
+-- Show (non-modal)
+wpfWindow.Show()
+-- Show modal: wpfWindow.ShowDialog()
+```
+
+**Key points:**
+- Always parent to Max via `ManagedServices.AppSDK.GetMaxHWND()` — otherwise window goes behind Max
+- Use `MaxCustomControls.dll` for themed controls matching 3ds Max appearance
+- WPF event handlers follow same rules as WinForms: must be global scope
+- **3ds Max 2026+**: .NET Core 8 migration — `CSharpCodeProvider.CompileAssemblyFromSource` removed, use new `CSharpCompilationHelper.Compile` instead

--- a/src/lifecycle.py
+++ b/src/lifecycle.py
@@ -1,0 +1,219 @@
+"""Connection lifecycle state machine for MaxClient.
+
+Tracks transport state through well-defined phases with timestamps and
+event history, inspired by claw-code's MCP lifecycle management pattern.
+
+States:
+    DISCONNECTED ─► CONNECTING ─► HANDSHAKE ─► READY
+         ▲              │             │           │
+         └──────────────┴─────────────┴───► ERROR
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ConnectionState(Enum):
+    """Well-defined connection lifecycle phases."""
+
+    DISCONNECTED = "disconnected"
+    CONNECTING = "connecting"
+    HANDSHAKE = "handshake"
+    READY = "ready"
+    ERROR = "error"
+
+
+# Valid state transitions
+_TRANSITIONS: dict[ConnectionState, frozenset[ConnectionState]] = {
+    ConnectionState.DISCONNECTED: frozenset({
+        ConnectionState.CONNECTING,
+    }),
+    ConnectionState.CONNECTING: frozenset({
+        ConnectionState.HANDSHAKE,
+        ConnectionState.ERROR,
+        ConnectionState.DISCONNECTED,
+    }),
+    ConnectionState.HANDSHAKE: frozenset({
+        ConnectionState.READY,
+        ConnectionState.ERROR,
+        ConnectionState.DISCONNECTED,
+    }),
+    ConnectionState.READY: frozenset({
+        ConnectionState.ERROR,
+        ConnectionState.DISCONNECTED,
+    }),
+    ConnectionState.ERROR: frozenset({
+        ConnectionState.CONNECTING,
+        ConnectionState.DISCONNECTED,
+    }),
+}
+
+
+@dataclass(frozen=True)
+class StateEvent:
+    """Immutable record of a state transition."""
+
+    from_state: ConnectionState
+    to_state: ConnectionState
+    timestamp: float
+    transport: str
+    detail: str = ""
+
+
+StateCallback = Callable[[StateEvent], None]
+
+
+class LifecycleManager:
+    """Tracks connection state with transition validation and event history.
+
+    Usage:
+        lm = LifecycleManager()
+        lm.on_state_change(my_callback)
+
+        lm.transition_to(ConnectionState.CONNECTING, "pipe", "opening pipe handle")
+        lm.transition_to(ConnectionState.HANDSHAKE, "pipe", "first command sent")
+        lm.transition_to(ConnectionState.READY, "pipe", "handshake ok")
+    """
+
+    _MAX_HISTORY = 50
+
+    def __init__(self) -> None:
+        self._state = ConnectionState.DISCONNECTED
+        self._transport = ""
+        self._history: list[StateEvent] = []
+        self._callbacks: list[StateCallback] = []
+        self._state_since = time.perf_counter()
+        self._ready_count = 0
+        self._error_count = 0
+
+    # ── Properties ───────────────────────────────────────────────
+
+    @property
+    def state(self) -> ConnectionState:
+        return self._state
+
+    @property
+    def transport(self) -> str:
+        return self._transport
+
+    @property
+    def is_ready(self) -> bool:
+        return self._state == ConnectionState.READY
+
+    @property
+    def state_duration_ms(self) -> float:
+        """Milliseconds spent in the current state."""
+        return (time.perf_counter() - self._state_since) * 1000.0
+
+    @property
+    def history(self) -> list[StateEvent]:
+        return list(self._history)
+
+    @property
+    def ready_count(self) -> int:
+        """Number of times the connection reached READY state."""
+        return self._ready_count
+
+    @property
+    def error_count(self) -> int:
+        """Number of times the connection entered ERROR state."""
+        return self._error_count
+
+    # ── Callbacks ────────────────────────────────────────────────
+
+    def on_state_change(self, callback: StateCallback) -> None:
+        """Register a callback invoked on every state transition."""
+        self._callbacks.append(callback)
+
+    # ── State transitions ────────────────────────────────────────
+
+    def transition_to(
+        self,
+        new_state: ConnectionState,
+        transport: str = "",
+        detail: str = "",
+    ) -> StateEvent:
+        """Transition to a new state. Raises ValueError on invalid transition."""
+        old_state = self._state
+        allowed = _TRANSITIONS.get(old_state, frozenset())
+
+        if new_state not in allowed:
+            raise ValueError(
+                f"Invalid transition: {old_state.value} -> {new_state.value}. "
+                f"Allowed: {', '.join(s.value for s in allowed)}"
+            )
+
+        event = StateEvent(
+            from_state=old_state,
+            to_state=new_state,
+            timestamp=time.perf_counter(),
+            transport=transport or self._transport,
+            detail=detail,
+        )
+
+        self._state = new_state
+        self._transport = transport or self._transport
+        self._state_since = event.timestamp
+
+        if new_state == ConnectionState.READY:
+            self._ready_count += 1
+        elif new_state == ConnectionState.ERROR:
+            self._error_count += 1
+
+        self._history.append(event)
+        if len(self._history) > self._MAX_HISTORY:
+            self._history = self._history[-self._MAX_HISTORY:]
+
+        logger.debug(
+            "lifecycle: %s -> %s [%s] %s",
+            old_state.value,
+            new_state.value,
+            event.transport,
+            detail,
+        )
+
+        for cb in self._callbacks:
+            try:
+                cb(event)
+            except Exception:
+                logger.warning("lifecycle callback error", exc_info=True)
+
+        return event
+
+    def reset(self) -> None:
+        """Force back to DISCONNECTED (e.g. on cleanup). Skips transition validation."""
+        if self._state != ConnectionState.DISCONNECTED:
+            event = StateEvent(
+                from_state=self._state,
+                to_state=ConnectionState.DISCONNECTED,
+                timestamp=time.perf_counter(),
+                transport=self._transport,
+                detail="forced reset",
+            )
+            self._state = ConnectionState.DISCONNECTED
+            self._state_since = event.timestamp
+            self._history.append(event)
+
+    def to_dict(self) -> dict[str, object]:
+        """Snapshot of lifecycle state for diagnostics (e.g. bridge status)."""
+        last_error: Optional[str] = None
+        for event in reversed(self._history):
+            if event.to_state == ConnectionState.ERROR:
+                last_error = event.detail
+                break
+
+        return {
+            "state": self._state.value,
+            "transport": self._transport,
+            "stateDurationMs": round(self.state_duration_ms, 1),
+            "readyCount": self._ready_count,
+            "errorCount": self._error_count,
+            "lastError": last_error,
+        }

--- a/src/max_client.py
+++ b/src/max_client.py
@@ -7,6 +7,8 @@ import time
 from typing import Any, Optional
 from uuid import uuid4
 
+from .lifecycle import ConnectionState, LifecycleManager
+
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
 DEFAULT_TIMEOUT = 120.0
@@ -85,6 +87,7 @@ class MaxClient:
         self.pipe_name = pipe_name
         self._pipe_handle: Optional[int] = None
         self._pipe_lock = threading.Lock()
+        self.lifecycle = LifecycleManager()
 
     @property
     def native_available(self) -> bool:
@@ -197,17 +200,35 @@ class MaxClient:
             "protocolVersion": 2,
         }, ensure_ascii=True)
 
-        if self.transport == "pipe":
-            response_data = self._send_via_pipe(request, effective_timeout)
-        elif self.transport == "tcp":
-            response_data = self._send_via_tcp(request, effective_timeout)
-        else:
-            try:
-                response_data = self._send_via_pipe(request, effective_timeout)
-            except (ConnectionError, TimeoutError):
-                response_data = self._send_via_tcp(request, effective_timeout)
+        lc = self.lifecycle
+        if lc.state == ConnectionState.DISCONNECTED:
+            lc.transition_to(ConnectionState.CONNECTING, detail=f"cmd_type={cmd_type}")
 
-        return self._parse_response(response_data, request_id, started_at)
+        try:
+            if self.transport == "pipe":
+                response_data = self._send_via_pipe(request, effective_timeout)
+            elif self.transport == "tcp":
+                response_data = self._send_via_tcp(request, effective_timeout)
+            else:
+                try:
+                    response_data = self._send_via_pipe(request, effective_timeout)
+                except (ConnectionError, TimeoutError):
+                    response_data = self._send_via_tcp(request, effective_timeout)
+        except (ConnectionError, TimeoutError) as exc:
+            if lc.state != ConnectionState.ERROR:
+                lc.transition_to(ConnectionState.ERROR, detail=str(exc))
+            raise
+
+        if lc.state == ConnectionState.CONNECTING:
+            lc.transition_to(ConnectionState.HANDSHAKE, detail="data received")
+
+        result = self._parse_response(response_data, request_id, started_at)
+
+        if lc.state in (ConnectionState.HANDSHAKE, ConnectionState.ERROR):
+            transport = "pipe" if self.transport != "tcp" and self._pipe_handle else "tcp"
+            lc.transition_to(ConnectionState.READY, transport=transport, detail="response ok")
+
+        return result
 
     # ── Named Pipe transport ─────────────────────────────────────
     def _send_via_pipe(self, request: str, timeout: float) -> bytes:

--- a/src/safety.py
+++ b/src/safety.py
@@ -1,0 +1,139 @@
+"""Safety gate for dangerous MCP tools.
+
+Classifies tools by risk level and injects warning metadata into responses
+for destructive operations, giving the AI agent context to confirm with users.
+
+Risk levels:
+    SAFE      — read-only, no scene mutation
+    CAUTION   — scene mutation, reversible (create, move, hide)
+    DANGEROUS — irreversible or high-impact (delete, reset, raw MAXScript)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class RiskLevel(Enum):
+    SAFE = "safe"
+    CAUTION = "caution"
+    DANGEROUS = "dangerous"
+
+
+@dataclass(frozen=True)
+class ToolRisk:
+    """Risk classification for a single tool or tool+args combo."""
+
+    level: RiskLevel
+    reason: str
+    suggestion: str = ""
+
+
+# ── Static tool risk registry ────────────────────────────────────
+
+_TOOL_RISKS: dict[str, ToolRisk] = {
+    "delete_objects": ToolRisk(
+        level=RiskLevel.DANGEROUS,
+        reason="Permanently removes objects from the scene",
+        suggestion="Use manage_scene(action='hold') first to create a restore point",
+    ),
+    "execute_maxscript": ToolRisk(
+        level=RiskLevel.DANGEROUS,
+        reason="Executes arbitrary MAXScript code — can modify or destroy scene data",
+        suggestion="Prefer dedicated tools over raw MAXScript when available",
+    ),
+}
+
+# Conditional risks: tool name -> (condition_fn, risk_if_true, risk_if_false)
+# condition_fn receives the tool's kwargs
+_CONDITIONAL_RISKS: dict[str, tuple[
+    type[object],  # placeholder for callable type
+    ToolRisk,
+    ToolRisk,
+]] = {}
+
+
+def _manage_scene_risk(**kwargs: object) -> ToolRisk:
+    """manage_scene is dangerous only for 'reset'; 'hold'/'info' are safe."""
+    action = str(kwargs.get("action", "")).lower().strip()
+    if action == "reset":
+        return ToolRisk(
+            level=RiskLevel.DANGEROUS,
+            reason="Resets the entire scene — all unsaved work will be lost",
+            suggestion="Use manage_scene(action='hold') first, or confirm with user",
+        )
+    if action in ("save",):
+        return ToolRisk(
+            level=RiskLevel.CAUTION,
+            reason="Overwrites the saved file on disk",
+        )
+    return ToolRisk(level=RiskLevel.SAFE, reason="Read-only or reversible operation")
+
+
+# ── Public API ───────────────────────────────────────────────────
+
+def classify_risk(tool_name: str, **kwargs: object) -> ToolRisk:
+    """Classify the risk level of a tool invocation.
+
+    Args:
+        tool_name: MCP tool function name (e.g. "delete_objects").
+        **kwargs: Tool arguments for conditional risk evaluation.
+
+    Returns:
+        ToolRisk with level, reason, and optional suggestion.
+    """
+    # Check conditional risks first (tool behavior depends on args)
+    if tool_name == "manage_scene":
+        return _manage_scene_risk(**kwargs)
+
+    # Static registry lookup
+    if tool_name in _TOOL_RISKS:
+        return _TOOL_RISKS[tool_name]
+
+    return ToolRisk(level=RiskLevel.SAFE, reason="")
+
+
+def format_safety_warning(risk: ToolRisk) -> str:
+    """Format a risk assessment as a human-readable warning prefix."""
+    if risk.level == RiskLevel.SAFE:
+        return ""
+
+    parts = [f"[{risk.level.value.upper()}] {risk.reason}"]
+    if risk.suggestion:
+        parts.append(f"Suggestion: {risk.suggestion}")
+    return " | ".join(parts)
+
+
+def wrap_with_safety(
+    tool_name: str,
+    result: str,
+    **kwargs: object,
+) -> str:
+    """Wrap a tool result with safety metadata if the tool is risky.
+
+    For DANGEROUS tools, prepends a warning to the result string.
+    For SAFE/CAUTION tools, returns the result unchanged.
+
+    This is designed to work within MCP's string return constraint —
+    no protocol changes needed.
+    """
+    risk = classify_risk(tool_name, **kwargs)
+
+    if risk.level == RiskLevel.SAFE:
+        return result
+
+    warning = format_safety_warning(risk)
+
+    if risk.level == RiskLevel.DANGEROUS:
+        logger.info("safety gate: %s -> %s", tool_name, risk.level.value)
+        return f"WARNING: {warning}\n---\n{result}"
+
+    # CAUTION: just log, don't modify output
+    logger.debug("safety note: %s -> %s", tool_name, risk.level.value)
+    return result

--- a/src/server.py
+++ b/src/server.py
@@ -61,7 +61,7 @@ def max_assistant() -> str:
         "Use capture_viewport for fast viewport context.\n"
         f"Reference resource: {SKILL_RESOURCE_URI}\n"
     )
-    return f"{base_rules}\nFull reference:\n\n{_read_skill_file()}"
+    return base_rules
 
 
 def main():

--- a/src/server.py
+++ b/src/server.py
@@ -1,10 +1,44 @@
 import logging
+import os
+import subprocess
+import sys
+import threading
 from functools import lru_cache
 from pathlib import Path
 from mcp.server.fastmcp import FastMCP
 from .max_client import MaxClient
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+_MAX_PROCESS_NAME = "3dsmax.exe"
+_WATCHDOG_INTERVAL = 10  # seconds
+
+
+def _is_3dsmax_running() -> bool:
+    """Check if 3dsmax.exe is running via tasklist."""
+    try:
+        result = subprocess.run(
+            ["tasklist", "/FI", f"IMAGENAME eq {_MAX_PROCESS_NAME}", "/NH"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return _MAX_PROCESS_NAME.lower() in result.stdout.lower()
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return True  # assume running if we can't check
+
+
+def _watchdog_loop() -> None:
+    """Background thread that exits the server when 3ds Max closes."""
+    import time
+
+    while True:
+        time.sleep(_WATCHDOG_INTERVAL)
+        if not _is_3dsmax_running():
+            logger.info("3ds Max is no longer running — shutting down MCP server.")
+            os._exit(0)
+
 
 mcp = FastMCP("3dsmax-mcp")
 client = MaxClient()
@@ -65,6 +99,14 @@ def max_assistant() -> str:
 
 
 def main():
+    if not _is_3dsmax_running():
+        logger.info("3ds Max is not running — MCP server will not start.")
+        sys.exit(0)
+
+    watchdog = threading.Thread(target=_watchdog_loop, daemon=True)
+    watchdog.start()
+    logger.info("3ds Max detected — starting MCP server (watchdog active).")
+
     mcp.run(transport="stdio")
 
 

--- a/src/tools/controllers.py
+++ b/src/tools/controllers.py
@@ -85,6 +85,78 @@ def _build_prop_lines(prefix: str, params: dict) -> list[str]:
     return lines
 
 
+def _build_controller_config(
+    ct: str,
+    script: Optional[str],
+    variables: Optional[list[dict]],
+    params: Optional[dict],
+    ctrl_var: str,
+) -> list[str]:
+    """Build MAXScript lines to configure a controller (variables, script, params)."""
+    lines = []
+
+    # Add node variables / constraint targets
+    if variables:
+        if ct in _SCRIPT_TYPES:
+            for var in variables:
+                vname = safe_string(var.get("var_name", ""))
+                vobj = safe_name(var.get("object", ""))
+                lines.append(f'local varNode = getNodeByName "{vobj}"')
+                lines.append(f'if varNode != undefined do {ctrl_var}.addNode "{vname}" varNode')
+        elif ct in _CONSTRAINT_TYPES:
+            for var in variables:
+                tobj = safe_name(var.get("object", ""))
+                weight = var.get("weight", 50.0)
+                lines.append(f'local tgtNode = getNodeByName "{tobj}"')
+                lines.append(f'if tgtNode != undefined do {ctrl_var}.appendTarget tgtNode {weight}')
+        elif ct == _LINK_TYPE:
+            for var in variables:
+                tobj = safe_name(var.get("object", ""))
+                frame = var.get("frame", 0)
+                lines.append(f'local tgtNode = getNodeByName "{tobj}"')
+                lines.append(f'if tgtNode != undefined do {ctrl_var}.addTarget tgtNode {frame}')
+        elif ct == _ATTACHMENT_TYPE:
+            for var in variables:
+                tobj = safe_name(var.get("object", ""))
+                face = var.get("face", 1)
+                lines.append(f'local tgtNode = getNodeByName "{tobj}"')
+                lines.append(f'if tgtNode != undefined do {ctrl_var}.appendTarget tgtNode {face}')
+        elif ct in _EXPRESSION_TYPES:
+            for var in variables:
+                vname = safe_string(var.get("var_name", ""))
+                tobj = safe_name(var.get("object", ""))
+                tpath = safe_string(var.get("target_param_path", ""))
+                tsep = "" if tpath.startswith("[") else "."
+                lines.append(f'local tgtNode = getNodeByName "{tobj}"')
+                lines.append(f'if tgtNode != undefined do (')
+                lines.append(f'    local tgtSA = execute("$\'" + tgtNode.name + "\'{tsep}{tpath}")')
+                lines.append(f'    if tgtSA != undefined do {ctrl_var}.addScalarTarget "{vname}" tgtSA.controller')
+                lines.append(f')')
+
+    # Set script/expression text
+    if script is not None:
+        safe_script = (script
+                       .replace("\\", "\\\\")
+                       .replace('"', '\\"')
+                       .replace("\n", "\\n")
+                       .replace("\r", "\\r")
+                       .replace("\t", "\\t"))
+        if ct in _SCRIPT_TYPES:
+            lines.append(f'{ctrl_var}.script = "{safe_script}"')
+        elif ct in _EXPRESSION_TYPES:
+            lines.append(f'{ctrl_var}.setExpression "{safe_script}"')
+            lines.append(f'{ctrl_var}.update()')
+
+    # Set arbitrary properties
+    if params:
+        lines.extend(_build_prop_lines(ctrl_var, params))
+
+    return lines
+
+
+# ── Standalone tools ────────────────────────────────────────────────
+
+
 @mcp.tool()
 def assign_controller(
     name: str,
@@ -95,49 +167,20 @@ def assign_controller(
     params: Optional[dict] = None,
     layer: bool = False,
 ) -> str:
-    """Create and assign a controller to a sub-anim track.
-
-    Assigns any supported controller type to a track, with optional initial
-    script text, node variables/constraint targets, and property values.
-
-    Use layer=True to add the controller on TOP of the existing one via a
-    list controller (e.g. add noise without losing the current position).
+    """Assign a controller to a sub-anim track. Use layer=True to add on top via list controller.
 
     Args:
-        name: Object name (e.g. "Sphere001").
-        param_path: Sub-anim path from list_wireable_params
-                    (e.g. "[#transform][#position][#z_position]").
-        controller_type: Controller type key. One of:
-            SCRIPT: "float_script", "position_script", "rotation_script",
-                    "scale_script", "point3_script"
-            CONSTRAINTS: "position_constraint", "orientation_constraint",
-                        "lookat_constraint", "path_constraint",
-                        "surface_constraint", "link_constraint",
-                        "attachment_constraint"
-            NOISE: "noise_float", "noise_position", "noise_rotation",
-                   "noise_scale"
-            LIST: "float_list", "position_list", "rotation_list", "scale_list"
-            EXPRESSION: "float_expression", "position_expression"
-            OTHER: "spring"
-        script: Script text for script controllers (full MAXScript supported),
-                or math expression for expression controllers (NO MAXScript,
-                only math with named variables like "x + 10").
-                To reference other objects, use float_script NOT float_expression.
-        variables: List of dicts for node references:
-            - Script controllers: [{"var_name": "ground", "object": "Plane001"}]
-              Creates name-independent node references via ctrl.addNode.
-            - Constraints: [{"object": "Target001", "weight": 50.0}]
-              Adds constraint targets via appendTarget.
-            - Link constraint: [{"object": "Parent001", "frame": 0}]
-              Adds link targets via addTarget.
-        params: Dict of controller properties to set
-                (e.g. {"seed": 42, "frequency": 0.5} for noise).
-        layer: If True, wraps existing controller in a list controller and
-               adds the new controller on top (preserves current value).
-               If the track already has a list controller, just appends.
-
-    Returns:
-        JSON with controller class, object, and param path.
+        name: Object name.
+        param_path: Sub-anim path (e.g. "[#transform][#position][#z_position]").
+        controller_type: One of: float_script, position_script, rotation_script, scale_script,
+            point3_script, position_constraint, orientation_constraint, lookat_constraint,
+            path_constraint, surface_constraint, link_constraint, attachment_constraint,
+            noise_float, noise_position, noise_rotation, noise_scale, float_list,
+            position_list, rotation_list, scale_list, float_expression, position_expression, spring.
+        script: Script text (script controllers) or math expression (expression controllers).
+        variables: Node refs — script: [{"var_name":"x","object":"Obj"}], constraint: [{"object":"Tgt","weight":50}].
+        params: Controller properties dict (e.g. {"seed":42,"frequency":0.5}).
+        layer: If True, wraps in list controller preserving current value.
     """
     if client.native_available:
         payload = {
@@ -223,93 +266,148 @@ def assign_controller(
     return response.get("result", str(response))
 
 
-def _build_controller_config(
-    ct: str,
-    script: Optional[str],
-    variables: Optional[list[dict]],
-    params: Optional[dict],
-    ctrl_var: str,
-) -> list[str]:
-    """Build MAXScript lines to configure a controller (variables, script, params)."""
-    lines = []
-
-    # Add node variables / constraint targets
-    if variables:
-        if ct in _SCRIPT_TYPES:
-            for var in variables:
-                vname = safe_string(var.get("var_name", ""))
-                vobj = safe_name(var.get("object", ""))
-                lines.append(f'local varNode = getNodeByName "{vobj}"')
-                lines.append(f'if varNode != undefined do {ctrl_var}.addNode "{vname}" varNode')
-        elif ct in _CONSTRAINT_TYPES:
-            for var in variables:
-                tobj = safe_name(var.get("object", ""))
-                weight = var.get("weight", 50.0)
-                lines.append(f'local tgtNode = getNodeByName "{tobj}"')
-                lines.append(f'if tgtNode != undefined do {ctrl_var}.appendTarget tgtNode {weight}')
-        elif ct == _LINK_TYPE:
-            for var in variables:
-                tobj = safe_name(var.get("object", ""))
-                frame = var.get("frame", 0)
-                lines.append(f'local tgtNode = getNodeByName "{tobj}"')
-                lines.append(f'if tgtNode != undefined do {ctrl_var}.addTarget tgtNode {frame}')
-        elif ct == _ATTACHMENT_TYPE:
-            for var in variables:
-                tobj = safe_name(var.get("object", ""))
-                face = var.get("face", 1)
-                lines.append(f'local tgtNode = getNodeByName "{tobj}"')
-                lines.append(f'if tgtNode != undefined do {ctrl_var}.appendTarget tgtNode {face}')
-        elif ct in _EXPRESSION_TYPES:
-            for var in variables:
-                vname = safe_string(var.get("var_name", ""))
-                tobj = safe_name(var.get("object", ""))
-                tpath = safe_string(var.get("target_param_path", ""))
-                tsep = "" if tpath.startswith("[") else "."
-                lines.append(f'local tgtNode = getNodeByName "{tobj}"')
-                lines.append(f'if tgtNode != undefined do (')
-                lines.append(f'    local tgtSA = execute("$\'" + tgtNode.name + "\'{tsep}{tpath}")')
-                lines.append(f'    if tgtSA != undefined do {ctrl_var}.addScalarTarget "{vname}" tgtSA.controller')
-                lines.append(f')')
-
-    # Set script/expression text
-    if script is not None:
-        safe_script = (script
-                       .replace("\\", "\\\\")
-                       .replace('"', '\\"')
-                       .replace("\n", "\\n")
-                       .replace("\r", "\\r")
-                       .replace("\t", "\\t"))
-        if ct in _SCRIPT_TYPES:
-            lines.append(f'{ctrl_var}.script = "{safe_script}"')
-        elif ct in _EXPRESSION_TYPES:
-            lines.append(f'{ctrl_var}.setExpression "{safe_script}"')
-            lines.append(f'{ctrl_var}.update()')
-
-    # Set arbitrary properties
-    if params:
-        lines.extend(_build_prop_lines(ctrl_var, params))
-
-    return lines
-
-
 @mcp.tool()
-def inspect_controller(
+def inspect_track_view(
+    name: str,
+    depth: int = 4,
+    filter: Optional[str] = None,
+    include_values: bool = True,
+) -> str:
+    """Inspect an object's controller/track tree in a Track View-style hierarchy.
+
+    Args:
+        name: Object name (e.g. "Box001")
+        depth: Max recursion depth (default 4, max 6)
+        filter: Optional case-insensitive substring filter on path/name/controller
+        include_values: Include compact current value strings when true
+    """
+    if client.native_available:
+        payload = _json.dumps({
+            "name": name,
+            "depth": min(max(int(depth), 1), 6),
+            "filter": filter or "",
+            "include_values": include_values,
+        })
+        response = client.send_command(payload, cmd_type="native:inspect_track_view")
+        return response.get("result", "")
+
+    safe_obj = safe_name(name)
+    safe_filter = safe_string((filter or "").lower())
+    max_depth = min(max(int(depth), 1), 6)
+    include_values_str = "true" if include_values else "false"
+
+    maxscript = f"""(
+    local esc = MCP_Server.escapeJsonString
+    local obj = getNodeByName "{safe_obj}"
+    if obj == undefined do return "{{\\"error\\":\\"Object not found: {safe_obj}\\"}}"
+
+    local filterStr = "{safe_filter}"
+    local includeValues = {include_values_str}
+
+    fn matchesFilter text filterText = (
+        if filterText == "" then return true
+        if text == undefined then return false
+        (findString (toLower text) filterText) != undefined
+    )
+
+    fn compactValue sub includeVals = (
+        if not includeVals then return ""
+        local valStr = try ((sub.value) as string) catch ""
+        valStr = esc valStr
+        if valStr.count > 120 do valStr = (substring valStr 1 120) + "..."
+        valStr
+    )
+
+    fn buildTrack sub path trackName depthLeft filterText includeVals = (
+        if depthLeft < 0 then return undefined
+
+        local ctrl = try (sub.controller) catch undefined
+        local ctrlClass = if ctrl != undefined then ((classof ctrl) as string) else ""
+        local ctrlSuper = if ctrl != undefined then ((superClassOf ctrl) as string) else ""
+        local rawName = if trackName != undefined then (trackName as string) else "?"
+        local pathStr = path
+        local valueStr = compactValue sub includeVals
+
+        local childrenJson = "["
+        local childCount = 0
+        local firstChild = true
+
+        if depthLeft > 0 do (
+            local numSubs = try (sub.numsubs) catch 0
+            for i = 1 to numSubs do (
+                local child = try (getSubAnim sub i) catch undefined
+                if child == undefined do continue
+                local childName = try ((getSubAnimName sub i) as string) catch undefined
+                if childName == undefined do continue
+                local childPath = pathStr + "[#" + childName + "]"
+                local childJson = buildTrack child childPath childName (depthLeft - 1) filterText includeVals
+                if childJson != undefined do (
+                    if not firstChild do childrenJson += ","
+                    firstChild = false
+                    childrenJson += childJson
+                    childCount += 1
+                )
+            )
+        )
+        childrenJson += "]"
+
+        local haystack = (toLower rawName) + " " + (toLower pathStr) + " " + (toLower ctrlClass)
+        local keep = matchesFilter haystack filterText or childCount > 0
+        if not keep then return undefined
+
+        local json = "{{"
+        json += "\\"name\\":\\"" + (esc rawName) + "\\""
+        json += ",\\"path\\":\\"" + (esc pathStr) + "\\""
+        if ctrlClass != "" then json += ",\\"controller\\":\\"" + (esc ctrlClass) + "\\""
+        if ctrlSuper != "" then json += ",\\"controllerSuperclass\\":\\"" + (esc ctrlSuper) + "\\""
+        if valueStr != "" then json += ",\\"value\\":\\"" + valueStr + "\\""
+        json += ",\\"childCount\\":" + (childCount as string)
+        json += ",\\"children\\":" + childrenJson
+        json += "}}"
+        json
+    )
+
+    local tracksJson = "["
+    local firstTrack = true
+    local rootCount = 0
+    local numSubs = try (obj.numsubs) catch 0
+    for i = 1 to numSubs do (
+        local child = try (getSubAnim obj i) catch undefined
+        if child == undefined do continue
+        local childName = try ((getSubAnimName obj i) as string) catch undefined
+        if childName == undefined do continue
+        local childPath = "[#" + childName + "]"
+        local childJson = buildTrack child childPath childName ({max_depth} - 1) filterStr includeValues
+        if childJson != undefined do (
+            if not firstTrack do tracksJson += ","
+            firstTrack = false
+            tracksJson += childJson
+            rootCount += 1
+        )
+    )
+    tracksJson += "]"
+
+    "{{" + \
+      "\\"object\\":\\"" + (esc obj.name) + "\\"," + \
+      "\\"class\\":\\"" + (esc ((classof obj) as string)) + "\\"," + \
+      "\\"depth\\":" + ({max_depth} as string) + "," + \
+      "\\"filter\\":\\"" + (esc filterStr) + "\\"," + \
+      "\\"rootTrackCount\\":" + (rootCount as string) + "," + \
+      "\\"tracks\\":" + tracksJson + \
+    "}}"
+)"""
+    response = client.send_command(maxscript, timeout=30.0)
+    return response.get("result", str(response))
+
+
+# ── Private helpers (merged tools) ──────────────────────────────────
+
+
+def _inspect_controller(
     name: str,
     param_path: str,
 ) -> str:
-    """Inspect the controller on a specific sub-anim track.
-
-    Returns a rich JSON object with controller class, properties, and
-    type-specific details (script text, node variables, constraint targets,
-    expression text, list sub-controllers).
-
-    Args:
-        name: Object name (e.g. "Sphere001").
-        param_path: Sub-anim path (e.g. "[#transform][#position][#z_position]").
-
-    Returns:
-        JSON with controller details, properties table, and type-specific sections.
-    """
+    """Inspect the controller on a specific sub-anim track."""
     if client.native_available:
         payload = _json.dumps({"name": name, "param_path": param_path})
         response = client.send_command(payload, cmd_type="native:inspect_controller")
@@ -455,150 +553,7 @@ def inspect_controller(
     return response.get("result", str(response))
 
 
-@mcp.tool()
-def inspect_track_view(
-    name: str,
-    depth: int = 4,
-    filter: Optional[str] = None,
-    include_values: bool = True,
-) -> str:
-    """Inspect an object's controller/track tree in a Track View-style hierarchy.
-
-    This is the browse-first companion to inspect_controller:
-    - walks sub-anims recursively
-    - reports track names, paths, controller classes, and child tracks
-    - optionally includes compact current values
-
-    Args:
-        name: Object name (e.g. "Box001")
-        depth: Max recursion depth (default 4, max 6)
-        filter: Optional case-insensitive substring filter on path/name/controller
-        include_values: Include compact current value strings when true
-
-    Returns:
-        JSON with object info and nested track tree.
-    """
-    if client.native_available:
-        payload = _json.dumps({
-            "name": name,
-            "depth": min(max(int(depth), 1), 6),
-            "filter": filter or "",
-            "include_values": include_values,
-        })
-        response = client.send_command(payload, cmd_type="native:inspect_track_view")
-        return response.get("result", "")
-
-    safe_obj = safe_name(name)
-    safe_filter = safe_string((filter or "").lower())
-    max_depth = min(max(int(depth), 1), 6)
-    include_values_str = "true" if include_values else "false"
-
-    maxscript = f"""(
-    local esc = MCP_Server.escapeJsonString
-    local obj = getNodeByName "{safe_obj}"
-    if obj == undefined do return "{{\\"error\\":\\"Object not found: {safe_obj}\\"}}"
-
-    local filterStr = "{safe_filter}"
-    local includeValues = {include_values_str}
-
-    fn matchesFilter text filterText = (
-        if filterText == "" then return true
-        if text == undefined then return false
-        (findString (toLower text) filterText) != undefined
-    )
-
-    fn compactValue sub includeVals = (
-        if not includeVals then return ""
-        local valStr = try ((sub.value) as string) catch ""
-        valStr = esc valStr
-        if valStr.count > 120 do valStr = (substring valStr 1 120) + "..."
-        valStr
-    )
-
-    fn buildTrack sub path trackName depthLeft filterText includeVals = (
-        if depthLeft < 0 then return undefined
-
-        local ctrl = try (sub.controller) catch undefined
-        local ctrlClass = if ctrl != undefined then ((classof ctrl) as string) else ""
-        local ctrlSuper = if ctrl != undefined then ((superClassOf ctrl) as string) else ""
-        local rawName = if trackName != undefined then (trackName as string) else "?"
-        local pathStr = path
-        local valueStr = compactValue sub includeVals
-
-        local childrenJson = "["
-        local childCount = 0
-        local firstChild = true
-
-        if depthLeft > 0 do (
-            local numSubs = try (sub.numsubs) catch 0
-            for i = 1 to numSubs do (
-                local child = try (getSubAnim sub i) catch undefined
-                if child == undefined do continue
-                local childName = try ((getSubAnimName sub i) as string) catch undefined
-                if childName == undefined do continue
-                local childPath = pathStr + "[#" + childName + "]"
-                local childJson = buildTrack child childPath childName (depthLeft - 1) filterText includeVals
-                if childJson != undefined do (
-                    if not firstChild do childrenJson += ","
-                    firstChild = false
-                    childrenJson += childJson
-                    childCount += 1
-                )
-            )
-        )
-        childrenJson += "]"
-
-        local haystack = (toLower rawName) + " " + (toLower pathStr) + " " + (toLower ctrlClass)
-        local keep = matchesFilter haystack filterText or childCount > 0
-        if not keep then return undefined
-
-        local json = "{{"
-        json += "\\"name\\":\\"" + (esc rawName) + "\\""
-        json += ",\\"path\\":\\"" + (esc pathStr) + "\\""
-        if ctrlClass != "" then json += ",\\"controller\\":\\"" + (esc ctrlClass) + "\\""
-        if ctrlSuper != "" then json += ",\\"controllerSuperclass\\":\\"" + (esc ctrlSuper) + "\\""
-        if valueStr != "" then json += ",\\"value\\":\\"" + valueStr + "\\""
-        json += ",\\"childCount\\":" + (childCount as string)
-        json += ",\\"children\\":" + childrenJson
-        json += "}}"
-        json
-    )
-
-    local tracksJson = "["
-    local firstTrack = true
-    local rootCount = 0
-    local numSubs = try (obj.numsubs) catch 0
-    for i = 1 to numSubs do (
-        local child = try (getSubAnim obj i) catch undefined
-        if child == undefined do continue
-        local childName = try ((getSubAnimName obj i) as string) catch undefined
-        if childName == undefined do continue
-        local childPath = "[#" + childName + "]"
-        local childJson = buildTrack child childPath childName ({max_depth} - 1) filterStr includeValues
-        if childJson != undefined do (
-            if not firstTrack do tracksJson += ","
-            firstTrack = false
-            tracksJson += childJson
-            rootCount += 1
-        )
-    )
-    tracksJson += "]"
-
-    "{{" + \
-      "\\"object\\":\\"" + (esc obj.name) + "\\"," + \
-      "\\"class\\":\\"" + (esc ((classof obj) as string)) + "\\"," + \
-      "\\"depth\\":" + ({max_depth} as string) + "," + \
-      "\\"filter\\":\\"" + (esc filterStr) + "\\"," + \
-      "\\"rootTrackCount\\":" + (rootCount as string) + "," + \
-      "\\"tracks\\":" + tracksJson + \
-    "}}"
-)"""
-    response = client.send_command(maxscript, timeout=30.0)
-    return response.get("result", str(response))
-
-
-@mcp.tool()
-def add_controller_target(
+def _add_controller_target(
     name: str,
     param_path: str,
     target_object: str,
@@ -606,25 +561,7 @@ def add_controller_target(
     weight: float = 50.0,
     frame: int = 0,
 ) -> str:
-    """Add a node variable or constraint target to an existing controller.
-
-    Works with script controllers (addNode), constraints (appendTarget),
-    link constraints (addTarget with frame), and expression controllers
-    (addScalarTarget).
-
-    Args:
-        name: Object name with the controller.
-        param_path: Sub-anim path to the controlled track.
-        target_object: Name of the target/reference object to add.
-        var_name: Variable name for script controllers (required for script
-                  controllers, e.g. "ground"). Also used as scalar name for
-                  expression controllers.
-        weight: Weight for constraint targets (default 50.0).
-        frame: Frame number for link constraint targets (default 0).
-
-    Returns:
-        Confirmation message.
-    """
+    """Add a node variable or constraint target to an existing controller."""
     # Always use MAXScript TCP path — ctrl.addNode triggers script re-evaluation
     # which causes re-entrancy inside the native ExecuteSync handler.
     safe_obj = safe_name(name)
@@ -686,36 +623,13 @@ def add_controller_target(
     return response.get("result", str(response))
 
 
-@mcp.tool()
-def set_controller_props(
+def _set_controller_props(
     name: str,
     param_path: str,
     script: Optional[str] = None,
     params: Optional[dict] = None,
 ) -> str:
-    """Modify script text or properties on an existing controller.
-
-    Use this to update a script controller's code, an expression controller's
-    expression, or set properties (noise seed/frequency, constraint weights, etc.)
-    without replacing the controller.
-
-    IMPORTANT: Float_Expression only supports simple math with named scalar
-    variables (added via add_controller_target). It does NOT support MAXScript
-    or object references like "$Cylinder001.height". If you need MAXScript
-    references to other objects, use float_script controller instead
-    (assign_controller with controller_type="float_script").
-
-    Args:
-        name: Object name.
-        param_path: Sub-anim path to the controlled track.
-        script: New script text for float_script controllers, or new math
-                expression for Float_Expression controllers (e.g. "x + 10",
-                NOT "$obj.height"). Expression controllers call update() after.
-        params: Dict of property names to values to set on the controller.
-
-    Returns:
-        Confirmation message.
-    """
+    """Update script text or properties on an existing controller without replacing it."""
     if client.native_available:
         payload = {
             "name": name,
@@ -764,3 +678,40 @@ def set_controller_props(
     maxscript = "(\n    " + "\n    ".join(lines) + "\n)"
     response = client.send_command(maxscript)
     return response.get("result", str(response))
+
+
+# ── Unified tool ────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def manage_controllers(
+    action: str,
+    name: str = "",
+    param_path: str = "",
+    target_object: str = "",
+    var_name: Optional[str] = None,
+    weight: float = 50.0,
+    frame: int = 0,
+    script: Optional[str] = None,
+    params: Optional[dict] = None,
+) -> str:
+    """Controller inspection and modification. Actions: inspect, add_target, set_props.
+
+    Args:
+        action: "inspect" | "add_target" | "set_props".
+        name: Object name.
+        param_path: Sub-anim path.
+        target_object: Target node name (for add_target).
+        var_name: Variable name for script controllers (for add_target).
+        weight: Constraint target weight (for add_target, default 50).
+        frame: Frame for link constraint (for add_target, default 0).
+        script: New script/expression text (for set_props).
+        params: Property dict (for set_props).
+    """
+    if action == "inspect":
+        return _inspect_controller(name, param_path)
+    if action == "add_target":
+        return _add_controller_target(name, param_path, target_object, var_name, weight, frame)
+    if action == "set_props":
+        return _set_controller_props(name, param_path, script, params)
+    return f"Unknown action: {action}. Use: inspect, add_target, set_props"

--- a/src/tools/data_channel.py
+++ b/src/tools/data_channel.py
@@ -54,107 +54,18 @@ _OP_IDS = {
 }
 
 
-@mcp.tool()
-def add_data_channel(
+# ── Private helpers (original tool bodies) ──────────────────────────
+
+
+def _add_data_channel(
     name: str,
     operators: DictList,
     order: Optional[IntList] = None,
     display: bool = True,
 ) -> str:
-    """Add a Data Channel modifier with a complete operator graph.
-
-    The Data Channel modifier is 3ds Max's node-based data processing system
-    (like Houdini VOPs) that lives in the modifier stack. It chains operators
-    that read mesh data, process it, and write to channels.
-
-    IMPORTANT: The object MUST be an Editable Mesh/Poly (use convertToMesh
-    or convertToPoly first).
-
-    Args:
-        name: The object name (e.g. "Sphere001").
-        operators: List of operator definitions. Each dict has:
-            - "type" (str): Operator type name. Available types:
-              INPUT:  "vertex_input", "face_input", "edge_input", "xyz_space",
-                      "component_space", "curvature", "velocity", "node_influence",
-                      "tension_deform", "distort", "maxscript", "expression_float",
-                      "expression_point3"
-              PROCESS: "vector", "scale", "clamp", "invert", "normalize", "curve",
-                       "smooth", "decay", "point3_to_float", "convert_subobject",
-                       "geo_quantize", "color_space"
-              OUTPUT: "vertex_output", "face_output", "edge_output"
-              COMPOSITE: "transform_elements", "color_elements", "delta_mush"
-            - "blend" (int, optional): Blend mode for this operator.
-              0=Replace, 1=Add, 2=Subtract, 3=Multiply, 4=Divide,
-              5=DotProduct, 6=CrossProduct. Default is Replace for
-              input operators and Add for others.
-            - "params" (dict, optional): Operator properties to set. Keys:
-              vertex_input:  input (0=Position, 100=Selection, 101=AvgNormal,
-                            102=MapCh1, 103=MapCh2, 1=SoftSel/VData),
-                            xyz (0=XYZ, 1=X, 2=Y, 3=Z)
-              vertex_output: output (0=Position, 1=VertColor, 2=MapChannel,
-                            3=Normals, 4=Selection, 5=VertCrease, 6=VData),
-                            channelNum (int), replace (0=Replace, 1=Add,
-                            2=Subtract, 3=Multiply)
-              face_input:    input (0=Selection, 1=MatID, 2=SmoothGroup,
-                            3=Area, 4=Normal, 5=Planarity)
-              face_output:   output (0=Selection, 1=MatID, 2=SmoothGroup),
-                            type (0=Replace, 1=Add, 2=Sub, 3=Mul)
-              edge_input:    input (0=Selection, 1=CreaseWeights, 2=EdgeAngle)
-              edge_output:   output (0=Selection, 1=CreaseWeights),
-                            type (0=Replace, 1=Add, 2=Sub, 3=Mul)
-              vector:        space (0=Add, 1=Subtract, 2=DotProduct, 3=CrossProduct,
-                            4=Multiply), dir (0=World, 1=Local, 2=Custom),
-                            x/y/z (floats), node (str, object name)
-              xyz_space:     space (0=Local, 1=World, 2=Node),
-                            normalize (bool), min/max (float)
-              component_space: component (0=X, 1=Y, 2=Z),
-                              space (0=Local, 1=World), normalize (bool)
-              scale:         scale (float)
-              clamp:         clampMin/clampMax (float)
-              normalize:     normalizeMin/normalizeMax (float),
-                            rangeOverride (bool), rangeMin/rangeMax (float)
-              invert:        invert (bool)
-              smooth:        iteration (int), smoothAmount (float)
-              decay:         decay (float), Samples (int), smooth (bool)
-              point3_to_float: floatType (0=Length, 1=X, 2=Y, 3=Z)
-              geo_quantize:  mode (0=ByVertex, 1=ByElement, 2=ByObject)
-              transform_elements: inputChannel (0=Stack, 1=SoftSel, 2=VColorLum,
-                            3=VColorXYZ, 4=None),
-                            transformType (0=Position, 1=Rotation, 2=Scale%,
-                            3=ScaleUniform), XEnable/YEnable/ZEnable (bool),
-                            xoffset1/yoffset1/zoffset1 (float, min values),
-                            xoffset2/yoffset2/zoffset2 (float, max values),
-                            randomize (bool), seed (int), phase (float)
-              color_elements: inputOption (0=VertColors, 1=Map, 2=SoftSel,
-                            3=FromStack), colorOption (0=Face, 1=Element),
-                            randomize (bool), color1/color2 (str, "color R G B")
-              curvature:     (uses defaults — curvature values auto-computed)
-              velocity:      timeoffset (int), worldSpace (bool)
-              node_influence: node (str), minRange/maxRange (float),
-                            minValue/maxValue (float), mode (0=Vertex, 1=Element)
-              distort:       strength (float), map (str, MAXScript map expression)
-              maxscript:     script (str), elementtype (0=Verts, 1=Faces),
-                            DataType (0=Float, 1=Point3)
-              delta_mush:    strength (float), iterations (int)
-        order: Processing order as list of 0-based operator indices.
-               Only include operators that are ACTIVE in the pipeline.
-               If not specified, all operators execute in definition order.
-        display: Enable viewport display (default True).
-
-    Returns:
-        JSON summary of the created Data Channel modifier and operators.
-
-    Example — Select vertices by slope (facing up):
-        operators=[
-            {"type": "vertex_input", "params": {"input": 101}},
-            {"type": "vector", "params": {"space": 2, "dir": 2, "z": 1.0}},
-            {"type": "clamp", "params": {"clampMin": 0.0, "clampMax": 1.0}},
-            {"type": "vertex_output", "params": {"output": 4}}
-        ]
-    """
+    """Add a Data Channel modifier with operator graph."""
     safe = safe_string(name)
 
-    # Build MAXScript to add DC modifier and configure operators
     lines = [
         f'local obj = getNodeByName "{safe}"',
         'if obj == undefined do return "Object not found"',
@@ -164,7 +75,6 @@ def add_data_channel(
         'local dcIF = dcMod.DataChannelModifier',
     ]
 
-    # Add each operator
     for i, op in enumerate(operators):
         op_type = op.get("type", "").lower()
         if op_type not in _OP_IDS:
@@ -172,17 +82,14 @@ def add_data_channel(
         id_a, id_b = _OP_IDS[op_type]
         lines.append(f'dcIF.AddOperator {id_a}L {id_b}L {i}')
 
-    # Configure operator parameters
     for i, op in enumerate(operators):
         params = op.get("params", {})
-        idx = i + 1  # 1-based in MAXScript
+        idx = i + 1
         for key, val in params.items():
             if key == "node" and isinstance(val, str):
-                # Node reference
                 safe_node = safe_string(val)
                 lines.append(f'dcMod.operators[{idx}].{key} = getNodeByName "{safe_node}"')
             elif key == "script" and isinstance(val, str):
-                # Script operator — need to escape the script content
                 safe_script = val.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
                 lines.append(f'dcMod.operators[{idx}].{key} = "{safe_script}"')
             elif isinstance(val, bool):
@@ -190,22 +97,18 @@ def add_data_channel(
             elif isinstance(val, (int, float)):
                 lines.append(f'dcMod.operators[{idx}].{key} = {val}')
             elif isinstance(val, str):
-                # String value — could be MAXScript expression like "color 255 0 0"
                 lines.append(f'dcMod.operators[{idx}].{key} = {val}')
 
-    # Set blend modes (operator_ops)
     for i, op in enumerate(operators):
         blend = op.get("blend")
         if blend is not None:
-            idx = i + 1  # 1-based
+            idx = i + 1
             lines.append(f'dcMod.operator_ops[{idx}] = {blend}')
 
-    # Set processing order
     if order is not None:
         order_str = ", ".join(str(o) for o in order)
         lines.append(f'dcMod.operator_order = #({order_str})')
 
-    # Build result
     lines.append('local result = "{"')
     lines.append('result += "\\"modifier\\": \\"Data Channel\\","')
     lines.append('result += "\\"operators\\": " + dcMod.operators.count as string + ","')
@@ -219,24 +122,11 @@ def add_data_channel(
     return response.get("result", str(response))
 
 
-@mcp.tool()
-def inspect_data_channel(
+def _inspect_data_channel(
     name: str,
     modifier_index: int = 1,
 ) -> str:
-    """Inspect a Data Channel modifier's operator graph.
-
-    Returns the full operator chain with all parameters, processing order,
-    and enabled states. Use this to understand existing DC setups or
-    verify a setup you just created.
-
-    Args:
-        name: The object name.
-        modifier_index: 1-based modifier stack index (default 1 = top).
-
-    Returns:
-        JSON with complete operator graph details.
-    """
+    """Inspect a Data Channel modifier's operator graph."""
     safe = safe_string(name)
     maxscript = f"""(
     local obj = getNodeByName "{safe}"
@@ -299,28 +189,13 @@ def inspect_data_channel(
     return response.get("result", str(response))
 
 
-@mcp.tool()
-def set_data_channel_operator(
+def _set_data_channel_operator(
     name: str,
     operator_index: int,
     params: dict,
     modifier_index: int = 1,
 ) -> str:
-    """Set properties on a specific operator in a Data Channel modifier.
-
-    Use this to modify an existing Data Channel operator without rebuilding
-    the entire graph. Useful for tweaking parameters after creation.
-
-    Args:
-        name: The object name.
-        operator_index: 1-based index of the operator to modify.
-        params: Dict of property names to values. See add_data_channel
-                for available properties per operator type.
-        modifier_index: 1-based modifier stack index (default 1).
-
-    Returns:
-        Confirmation with the updated operator state.
-    """
+    """Set properties on a specific operator in a Data Channel modifier."""
     safe = safe_string(name)
 
     lines = [
@@ -354,8 +229,7 @@ def set_data_channel_operator(
     return response.get("result", str(response))
 
 
-@mcp.tool()
-def add_dc_script_operator(
+def _add_dc_script_operator(
     name: str,
     script: str,
     element_type: int = 0,
@@ -363,47 +237,10 @@ def add_dc_script_operator(
     output_to: str = "selection",
     modifier_index: int = 0,
 ) -> str:
-    """Add a Data Channel modifier with a MAXScript operator for custom per-vertex/face logic.
-
-    The Script Operator is the most powerful DC operator — it lets you write
-    arbitrary MAXScript that processes every vertex or face. Perfect for
-    effects that can't be achieved with built-in operators.
-
-    The script must define:
-        on Process theNode theMesh elementType outputType outputArray do (...)
-
-    Args:
-        theNode: The scene node being processed.
-        theMesh: PolyMesh copy to analyze (use polyop.* functions).
-        elementType: 1=Vertices, 2=Faces (set by the engine).
-        outputType: 1=Floats, 2=Point3s (set by the engine).
-        outputArray: Array to fill with per-vertex/face values.
-
-    Args:
-        name: The object name.
-        script: The MAXScript code for the Process function. You can provide
-                just the body or the full "on Process..." definition.
-                If the body-only form is used, it will be wrapped automatically.
-        element_type: What to process: 0=Vertices, 1=Faces.
-        data_type: Output data type: 0=Float, 1=Point3.
-        output_to: Where to output. One of:
-            "selection" — vertex/face selection weight (default)
-            "position" — vertex position
-            "vertex_color" — vertex color channel
-            "map_channel" — map channel (UV)
-            "normals" — vertex normals
-            "mat_id" — face material ID (faces only)
-        modifier_index: If > 0, add the script operator to an existing DC
-                       modifier at this stack index instead of creating new.
-
-    Returns:
-        Confirmation with created modifier info.
-    """
+    """Add a Data Channel with MAXScript operator for custom per-vertex/face logic."""
     safe = safe_string(name)
 
-    # Wrap script if needed
     if "on Process" not in script:
-        # User provided body-only — wrap it
         script = f"""on Process theNode theMesh elementType outputType outputArray do
 (
     if theMesh == undefined then return 0
@@ -412,7 +249,6 @@ def add_dc_script_operator(
 {script}
 )"""
 
-    # Escape script for MAXScript string
     safe_script = (script
                    .replace("\\", "\\\\")
                    .replace('"', '\\"')
@@ -420,23 +256,20 @@ def add_dc_script_operator(
                    .replace("\r", "\\r")
                    .replace("\t", "\\t"))
 
-    # Determine output operator and params
     output_config = {
-        "selection":     ("vertex_output", 4, 1),   # output=4(selection), channelNum=1
-        "position":      ("vertex_output", 0, 1),   # output=0(position)
-        "vertex_color":  ("vertex_output", 1, 0),   # output=1(vertColor)
-        "map_channel":   ("vertex_output", 2, 1),   # output=2(mapChannel), channelNum=1
-        "normals":       ("vertex_output", 3, 1),   # output=3(normals)
-        "mat_id":        ("face_output", 1, 0),      # face output=1(matID)
+        "selection":     ("vertex_output", 4, 1),
+        "position":      ("vertex_output", 0, 1),
+        "vertex_color":  ("vertex_output", 1, 0),
+        "map_channel":   ("vertex_output", 2, 1),
+        "normals":       ("vertex_output", 3, 1),
+        "mat_id":        ("face_output", 1, 0),
     }
 
     out_type, out_val, out_chan = output_config.get(output_to, ("vertex_output", 4, 1))
 
-    # Build MAXScript
     mxs_id_a, mxs_id_b = _OP_IDS["maxscript"]
 
     if modifier_index > 0:
-        # Add to existing DC modifier
         lines = [
             f'local obj = getNodeByName "{safe}"',
             f'if obj == undefined do return "Object not found: {safe}"',
@@ -451,7 +284,6 @@ def add_dc_script_operator(
             f'scriptOp.DataType = {data_type}',
         ]
     else:
-        # Create new DC modifier with script + output
         out_id_a, out_id_b = _OP_IDS[out_type]
         lines = [
             f'local obj = getNodeByName "{safe}"',
@@ -460,15 +292,11 @@ def add_dc_script_operator(
             'dcMod.display = true',
             'addModifier obj dcMod',
             'local dcIF = dcMod.DataChannelModifier',
-            # Add script operator
             f'dcIF.AddOperator {mxs_id_a}L {mxs_id_b}L 0',
-            # Add output operator
             f'dcIF.AddOperator {out_id_a}L {out_id_b}L 1',
-            # Configure script operator
             f'dcMod.operators[1].script = "{safe_script}"',
             f'dcMod.operators[1].elementtype = {element_type}',
             f'dcMod.operators[1].DataType = {data_type}',
-            # Configure output
             f'dcMod.operators[2].output = {out_val}',
             f'dcMod.operators[2].channelNum = {out_chan}',
         ]
@@ -480,15 +308,8 @@ def add_dc_script_operator(
     return response.get("result", str(response))
 
 
-@mcp.tool()
-def list_dc_presets() -> str:
-    """List all available Data Channel modifier presets.
-
-    Presets are saved DC operator graphs that can be loaded onto any object.
-
-    Returns:
-        JSON list of preset names.
-    """
+def _list_dc_presets() -> str:
+    """List all available Data Channel modifier presets."""
     maxscript = """(
     local b = Box name:"__dc_temp__" length:1 width:1 height:1
     convertToMesh b
@@ -513,22 +334,11 @@ def list_dc_presets() -> str:
     return response.get("result", str(response))
 
 
-@mcp.tool()
-def load_dc_preset(
+def _load_dc_preset(
     name: str,
     preset_name: str,
 ) -> str:
-    """Load a Data Channel modifier preset onto an object.
-
-    Adds a Data Channel modifier and loads the named preset graph.
-
-    Args:
-        name: The object name.
-        preset_name: Name of the preset to load.
-
-    Returns:
-        Confirmation.
-    """
+    """Load a Data Channel modifier preset onto an object."""
     safe = safe_string(name)
     safe_preset = safe_string(preset_name)
     maxscript = f"""(
@@ -542,3 +352,54 @@ def load_dc_preset(
 )"""
     response = client.send_command(maxscript)
     return response.get("result", str(response))
+
+
+# ── Unified tool ────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def manage_data_channel(
+    action: str,
+    name: str = "",
+    operators: Optional[DictList] = None,
+    order: Optional[IntList] = None,
+    display: bool = True,
+    modifier_index: int = 1,
+    operator_index: int = 0,
+    params: Optional[dict] = None,
+    script: str = "",
+    element_type: int = 0,
+    data_type: int = 0,
+    output_to: str = "selection",
+    preset_name: str = "",
+) -> str:
+    """Data Channel modifier management. Actions: add, inspect, set_operator, add_script, list_presets, load_preset.
+
+    Args:
+        action: "add"|"inspect"|"set_operator"|"add_script"|"list_presets"|"load_preset".
+        name: Object name.
+        operators: Operator list for add (type, blend, params dicts).
+        order: Processing order as 0-based indices (for add).
+        display: Viewport display (for add).
+        modifier_index: 1-based stack index.
+        operator_index: 1-based operator index (for set_operator).
+        params: Property dict (for set_operator).
+        script: MAXScript body (for add_script).
+        element_type: 0=Vertices, 1=Faces (for add_script).
+        data_type: 0=Float, 1=Point3 (for add_script).
+        output_to: Output target (for add_script).
+        preset_name: Preset name (for load_preset).
+    """
+    if action == "add":
+        return _add_data_channel(name, operators or [], order, display)
+    if action == "inspect":
+        return _inspect_data_channel(name, modifier_index)
+    if action == "set_operator":
+        return _set_data_channel_operator(name, operator_index, params or {}, modifier_index)
+    if action == "add_script":
+        return _add_dc_script_operator(name, script, element_type, data_type, output_to, modifier_index if modifier_index != 1 else 0)
+    if action == "list_presets":
+        return _list_dc_presets()
+    if action == "load_preset":
+        return _load_dc_preset(name, preset_name)
+    return f"Unknown action: {action}. Use: add, inspect, set_operator, add_script, list_presets, load_preset"

--- a/src/tools/effects.py
+++ b/src/tools/effects.py
@@ -9,19 +9,11 @@ import json
 from ..server import mcp, client
 
 
-@mcp.tool()
-def get_effects() -> str:
-    """List all atmospheric effects and render effects in the scene.
+# ── Private helpers (original tool bodies) ──────────────────────────
 
-    Use this when asked about fog, volume effects, lens effects, or any
-    scene-level post-processing. These are NOT per-object — they're global
-    scene effects. Atmospherics include Fog, Volume Fog, Volume Light,
-    Fire Effect, etc. Render effects include Lens Effects, Blur, etc.
 
-    Returns:
-        JSON with atmospheric and render effect lists, including class,
-        active state, and which scene objects reference each effect.
-    """
+def _list_effects() -> str:
+    """List all atmospheric and render effects in the scene."""
     if client.native_available:
         response = client.send_command("{}", cmd_type="native:get_effects")
         return response.get("result", '{"atmospherics":[],"renderEffects":[]}')
@@ -61,21 +53,12 @@ def get_effects() -> str:
     return response.get("result", '{"atmospherics":[],"renderEffects":[]}')
 
 
-@mcp.tool()
-def toggle_effect(
+def _toggle_effect(
     index: int,
     effect_type: str = "atmospheric",
     active: bool = True,
 ) -> str:
-    """Enable or disable an atmospheric or render effect by index.
-
-    Args:
-        index: 1-based index of the effect (from get_effects).
-        effect_type: "atmospheric" or "render_effect".
-        active: True to enable, False to disable.
-
-    Returns confirmation.
-    """
+    """Enable or disable an effect by index."""
     if client.native_available:
         payload = json.dumps({"index": index, "effect_type": effect_type, "active": active})
         response = client.send_command(payload, cmd_type="native:toggle_effect")
@@ -107,19 +90,11 @@ def toggle_effect(
     return response.get("result", "")
 
 
-@mcp.tool()
-def delete_effect(
+def _delete_effect(
     index: int,
     effect_type: str = "atmospheric",
 ) -> str:
-    """Delete an atmospheric or render effect by index.
-
-    Args:
-        index: 1-based index of the effect (from get_effects).
-        effect_type: "atmospheric" or "render_effect".
-
-    Returns confirmation.
-    """
+    """Delete an effect by index."""
     if client.native_available:
         payload = json.dumps({"index": index, "effect_type": effect_type})
         response = client.send_command(payload, cmd_type="native:delete_effect")
@@ -149,3 +124,30 @@ def delete_effect(
         )"""
     response = client.send_command(maxscript)
     return response.get("result", "")
+
+
+# ── Unified tool ────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def manage_effects(
+    action: str,
+    index: int = 0,
+    effect_type: str = "atmospheric",
+    active: bool = True,
+) -> str:
+    """Manage atmospheric and render effects. Actions: list, toggle, delete.
+
+    Args:
+        action: "list" | "toggle" | "delete".
+        index: 1-based effect index (for toggle/delete).
+        effect_type: "atmospheric" or "render_effect".
+        active: Enable/disable state (for toggle).
+    """
+    if action == "list":
+        return _list_effects()
+    if action == "toggle":
+        return _toggle_effect(index, effect_type, active)
+    if action == "delete":
+        return _delete_effect(index, effect_type)
+    return f"Unknown action: {action}. Use: list, toggle, delete"

--- a/src/tools/execute.py
+++ b/src/tools/execute.py
@@ -3,21 +3,11 @@ from ..server import mcp, client
 
 @mcp.tool()
 def execute_maxscript(code: str = "", command: str = "") -> str:
-    """Execute arbitrary MAXScript code in 3ds Max and return the result.
-
-    The code is run via MAXScript's execute() function. The return value
-    is the string representation of whatever the last expression evaluates to.
-
-    This is NOT a shell — do not send PowerShell/bash commands here.
-
-    Examples:
-        execute_maxscript("objects.count")
-        execute_maxscript("sphere radius:25 pos:[0,0,0]")
-        execute_maxscript("for o in selection collect o.name")
+    """Execute arbitrary MAXScript code in 3ds Max. Not a shell.
 
     Args:
         code: MAXScript code to execute.
-        command: Alias for code (use either one).
+        command: Alias for code.
     """
     script = code or command
     if not script:

--- a/src/tools/execute.py
+++ b/src/tools/execute.py
@@ -1,4 +1,5 @@
 from ..server import mcp, client
+from ..safety import wrap_with_safety
 
 
 @mcp.tool()
@@ -13,4 +14,4 @@ def execute_maxscript(code: str = "", command: str = "") -> str:
     if not script:
         return "Error: provide MAXScript code in the 'code' parameter"
     response = client.send_command(script, cmd_type="maxscript")
-    return response.get("result", "")
+    return wrap_with_safety("execute_maxscript", response.get("result", ""))

--- a/src/tools/file_access.py
+++ b/src/tools/file_access.py
@@ -15,26 +15,12 @@ def inspect_max_file(
     list_objects: bool = False,
     list_classes: bool = False,
 ) -> str:
-    """Inspect an external .max file without opening it.
-
-    Reads OLE metadata (file size, dates, author, title, comments) directly
-    from the file's structured storage — no scene load required.
-
-    With list_classes=True, reads the binary ClassDirectory3 stream to show
-    every material, modifier, geometry, texture, and controller class used
-    in the file. This is pure OLE reading — no scene load, no main thread.
-
-    With list_objects=True, lists all object names (uses merge-list API,
-    slightly slower).
+    """Inspect a .max file without opening it (OLE metadata, class directory, object list).
 
     Args:
         file_path: Full path to the .max file.
-        list_objects: If True, also list all object names in the file.
-        list_classes: If True, read the class directory to show all material,
-                      modifier, geometry, and texture classes used in the file.
-
-    Returns:
-        JSON with file metadata and optionally object names and class inventory.
+        list_objects: Also list all object names (slower, uses merge-list API).
+        list_classes: Read ClassDirectory3 to show all classes used in the file.
     """
     payload = json.dumps({
         "file_path": file_path,
@@ -52,24 +38,13 @@ def merge_from_file(
     select_merged: bool = True,
     duplicate_action: str = "rename",
 ) -> str:
-    """Merge objects from an external .max file into the current scene.
-
-    Supports selective merging (specific objects by name) or full merge.
-    Uses the SDK's MergeFromFile with configurable duplicate handling.
+    """Merge objects from a .max file into the current scene.
 
     Args:
-        file_path: Full path to the .max file to merge from.
-        object_names: Optional list of specific object names to merge.
-                      If empty/None, merges all objects.
-        select_merged: If True, select the merged objects after import.
-        duplicate_action: How to handle duplicate names:
-            - "rename": Auto-rename merged objects (default)
-            - "skip": Don't merge objects with existing names
-            - "merge": Keep both old and new
-            - "delete_old": Replace existing objects
-
-    Returns:
-        JSON with list of merged object names and count.
+        file_path: Full path to the .max file.
+        object_names: Specific objects to merge (None = all).
+        select_merged: Select merged objects after import.
+        duplicate_action: "rename" | "skip" | "merge" | "delete_old".
     """
     payload = {
         "file_path": file_path,
@@ -89,15 +64,9 @@ def batch_file_info(
 ) -> str:
     """Read metadata from multiple .max files in a single call.
 
-    Metadata-only mode runs in parallel threads for maximum speed.
-    With list_objects=True, object listing runs sequentially on the main thread.
-
     Args:
         file_paths: List of full paths to .max files.
-        list_objects: If True, also list object names from each file.
-
-    Returns:
-        JSON array with metadata for each file.
+        list_objects: Also list object names from each file.
     """
     payload = json.dumps({
         "file_paths": file_paths,
@@ -145,25 +114,12 @@ def search_max_files(
 ) -> str:
     """Search .max files in a folder for objects matching a name pattern.
 
-    Scans every .max file in the folder, lists all objects, and filters
-    by the given wildcard pattern. Designed to handle entire drives —
-    files are scanned in batches and output is token-optimized.
-
-    When pattern is "*", returns a compact summary per file (count only).
-    When pattern is specific, returns matching object names (capped per file).
-    Use inspect_max_file on a specific file to get its full object list.
-
     Args:
-        folder: Folder path to scan for .max files.
-        pattern: Wildcard pattern to match object names (e.g. "Fridge*",
-                 "*Light*", "CC_Base_*"). Default "*" returns summary only.
-        recursive: If True, scan subfolders too. Default True.
-        max_matches_per_file: Cap matched names per file (0 = auto: 20 for
-                              specific patterns, 0 for summary mode).
-        max_files: Stop after this many files (0 = no limit).
-
-    Returns:
-        JSON with matching objects grouped by file. Compact output by default.
+        folder: Folder path to scan.
+        pattern: Wildcard for object names (default "*" = summary only).
+        recursive: Scan subfolders (default True).
+        max_matches_per_file: Cap matched names per file (0 = auto).
+        max_files: Stop after N files (0 = no limit).
     """
     p = Path(folder)
     if not p.is_dir():

--- a/src/tools/floor_plan.py
+++ b/src/tools/floor_plan.py
@@ -305,28 +305,14 @@ def build_floor_plan(
     doors: DictList = [],
     options: dict[str, Any] | None = None,
 ) -> str:
-    """Build a 2D floor plan from grid-based room definitions.
-
-    Creates a SplineShape with wall segments and optional room labels.
-    Rooms are defined by grid cells; walls auto-detected at boundaries;
-    doors cut gaps in wall segments.
+    """Build a 2D floor plan from grid-based room definitions with auto-detected walls and door gaps.
 
     Args:
-        location: Centre point [x, y, z]. Z=0 means ground level.
-        cell_size: Grid cell size in cm (default 100 = 1 meter per cell).
-        rooms: List of room definitions. Each: {"name": str, "cells": [[col,row], ...]}.
-        doors: List of door specs. Each: {"between": ["RoomA", "RoomB"|null], "position": 0-1, "width": cm}.
-        options: Optional overrides:
-            name_prefix (str, default "FP"),
-            show_labels (bool, default true),
-            label_size (float, default 20),
-            extrude_height (float) — add Extrude modifier for 3D walls,
-            wall_thickness (float) — add Shell modifier,
-            wall_color ([r,g,b]) — wirecolor for wall spline,
-            label_color ([r,g,b]) — wirecolor for text labels.
-
-    Returns:
-        JSON with created objects and organiser dummy name.
+        location: Centre point [x, y, z].
+        cell_size: Grid cell size in cm (default 100).
+        rooms: Room defs: [{"name": str, "cells": [[col,row], ...]}].
+        doors: Door specs: [{"between": ["A", "B"|null], "position": 0-1, "width": cm}].
+        options: Overrides: name_prefix, show_labels, label_size, extrude_height, wall_thickness, wall_color, label_color.
     """
     opts = options or {}
     prefix = opts.get("name_prefix", "FP")

--- a/src/tools/identify.py
+++ b/src/tools/identify.py
@@ -16,23 +16,9 @@ def _sanitize_filename(name: str) -> str:
 
 @mcp.tool()
 def isolate_and_capture_selected() -> str:
-    """Capture isolated viewport screenshots of each selected object (resolves to top-level parents).
+    """Capture isolated viewport screenshots of each selected object (one per instance group).
 
-    Detects instances (objects sharing the same baseObject) and only captures
-    one representative per instance group — avoiding redundant identification.
-
-    For each unique top-level parent among the selection:
-      - Hides all other objects
-      - Selects it and all its descendants
-      - Zooms extents on the selection
-      - Captures the viewport to a PNG file
-      - Restores visibility
-
-    Returns JSON array:
-      [{"name": "Box001", "image_path": "C:/temp/...", "instances": ["Box001", "Box002", "Box003"]}, ...]
-
-    The "instances" array lists ALL object names that share the same base object.
-    The orchestrator should identify once and rename all instances from that result.
+    Returns JSON: [{"name", "image_path", "instances": [...]}]
     """
     capture_dir = os.path.join(COMMS_DIR, "identify").replace("\\", "/")
 
@@ -141,13 +127,10 @@ def isolate_and_capture_selected() -> str:
 
 @mcp.tool()
 def batch_rename_objects(renames_json: str) -> str:
-    """Rename multiple objects in a single batch operation.
+    """Rename multiple objects in a single batch.
 
     Args:
-        renames_json: JSON string array of renames, e.g.
-            [{"old_name": "Box001", "new_name": "House"}, ...]
-
-    Returns confirmation summary of renamed objects.
+        renames_json: JSON array of {"old_name", "new_name"} entries.
     """
     renames = json.loads(renames_json)
 

--- a/src/tools/inspect.py
+++ b/src/tools/inspect.py
@@ -12,17 +12,10 @@ from src.helpers.maxscript import safe_string
 
 @mcp.tool()
 def inspect_object(name: str) -> str:
-    """Get comprehensive properties of an object for exploration.
-
-    Use this as the FIRST step when you need to understand an object —
-    gives you everything at a glance: class, transform, hierarchy, modifiers,
-    material, mesh stats, bounding box, render flags, and instance status.
-    Prefer this over get_object_properties for a richer overview.
+    """Comprehensive object inspection: class, transform, hierarchy, modifiers, material, mesh stats, bbox.
 
     Args:
-        name: The object name (e.g. "Box001")
-
-    Returns detailed JSON property dump.
+        name: Object name.
     """
     if client.native_available:
         try:
@@ -139,26 +132,12 @@ def inspect_properties(
     target: str = "object",
     modifier_index: int = 0,
 ) -> str:
-    """Deep-inspect all properties of an object, modifier, base object, or material.
-
-    Use this BEFORE setting any property via set_object_property or execute_maxscript —
-    it tells you the exact property names, current values, and declared types
-    (e.g. "worldUnits", "texturemap", "percent") so you never guess wrong.
-    Use target="baseobject" for parametric params (Box length/width/height),
-    target="modifier" to see modifier params, target="material" for material slots.
+    """Deep-inspect all properties with names, values, and declared types.
 
     Args:
-        name: The object name (e.g. "Box001")
-        target: What to inspect:
-            - "object" — the node itself
-            - "baseobject" — the base parametric object (e.g. Box params)
-            - "modifier" — a specific modifier (use modifier_index)
-            - "material" — the assigned material
-        modifier_index: 1-based modifier index (only used when target="modifier")
-
-    Returns:
-        JSON with all properties, their current values, runtime types,
-        and declared types.
+        name: Object name.
+        target: "object" | "baseobject" | "modifier" | "material".
+        modifier_index: 1-based index (when target="modifier").
     """
     if client.native_available:
         try:
@@ -265,46 +244,19 @@ def inspect_properties(
 
 
 @mcp.tool()
-def inspect_modifier_properties(name: str, modifier_index: int) -> str:
-    """Inspect all properties of a specific modifier on an object.
-
-    Shortcut for inspect_properties with target="modifier".
-    Use this when you need to know what parameters a modifier exposes
-    before changing them (e.g. check TurboSmooth has "iterations" not "subdivisions").
-
-    Args:
-        name: The object name (e.g. "Box001")
-        modifier_index: 1-based index in the modifier stack.
-
-    Returns:
-        JSON with all modifier properties, values, and types.
-    """
-    return inspect_properties(name, target="modifier", modifier_index=modifier_index)
-
-
-@mcp.tool()
 def introspect_osl(
     class_name: str = "",
     name: str = "",
     osl_file: str = "",
     sub_material_index: int = 0,
 ) -> str:
-    """Inspect the API surface of any material, texturemap, or modifier class.
-
-    Returns classOf, superClassOf, all properties with types, interfaces with
-    methods, and output channels. Lightweight MAXScript reflection — bounded
-    output, no 600K blowups.
-
-    Use this instead of introspect_class when you need a quick property/interface
-    dump for materials, texturemaps, or OSLMaps.
+    """Inspect API surface of a material/texturemap/modifier class (properties, interfaces, output channels).
 
     Args:
-        class_name: Class to inspect (e.g. "OSLMap", "PhysicalMaterial",
-                    "Bitmaptexture", "TurboSmooth"). Creates a temp instance.
-        name: Object name — inspects its material instead of creating temp.
-        osl_file: For OSLMap: .osl filename (e.g. "UberBitmap2") or full path.
-                  Short names resolve to (getDir #maxRoot)/OSL/<name>.osl
-        sub_material_index: Sub-material slot (1-based). 0 = top material.
+        class_name: Class to inspect (creates temp instance).
+        name: Object name (inspects its material instead of creating temp).
+        osl_file: For OSLMap: .osl filename or full path.
+        sub_material_index: Sub-material slot (1-based, 0 = top).
     """
     if not class_name and not name:
         return '{"error":"Provide class_name or name"}'

--- a/src/tools/learning.py
+++ b/src/tools/learning.py
@@ -4,52 +4,22 @@ import json
 from ..server import mcp, client
 
 
-@mcp.tool()
-def walk_references(
-    name: str,
-    max_depth: int = 4,
-) -> str:
-    """Walk the full reference dependency graph of a scene object.
+# ── Private helpers ─────────────────────────────────────────────────
 
-    Shows exactly how materials, modifiers, controllers, textures, and nodes
-    connect to each other through Max's reference system. Use this to understand
-    why changing one object affects another, or to map a complex shader network.
 
-    Args:
-        name: Object name to walk from.
-        max_depth: Max recursion depth (default 4, max 8). Deeper = more detail
-                   but larger output.
-
-    Returns:
-        JSON tree showing the full reference graph with class names and superclasses.
-    """
+def _walk_references(name: str, max_depth: int = 3) -> str:
+    """Walk the reference dependency graph of a scene object."""
     payload = json.dumps({"name": name, "max_depth": max_depth})
     response = client.send_command(payload, cmd_type="native:walk_references")
     return response.get("result", "{}")
 
 
-@mcp.tool()
-def map_class_relationships(
+def _map_class_relationships(
     pattern: str = "",
     superclass: str = "",
     limit: int = 100,
 ) -> str:
-    """Map which classes can reference which types via their ParamBlock2 params.
-
-    Scans the DLL class directory and finds every parameter that accepts a node,
-    material, texturemap, or reference target. Builds a relationship graph showing
-    "TurboSmooth accepts nothing", "Forest_Pro accepts nodes + texturemaps", etc.
-
-    Use this to learn which classes plug into which slots without reading docs.
-
-    Args:
-        pattern: Wildcard filter for class names (e.g. "*Vray*", "Forest*").
-        superclass: Filter by superclass: geometry, modifier, material, texturemap, etc.
-        limit: Max classes to return (default 100).
-
-    Returns:
-        JSON array of classes with their accepted reference types and param names.
-    """
+    """Map which classes accept which reference types via ParamBlock2 params."""
     payload = {}
     if pattern:
         payload["pattern"] = pattern
@@ -64,58 +34,58 @@ def map_class_relationships(
     return response.get("result", "{}")
 
 
-@mcp.tool()
-def learn_scene_patterns() -> str:
-    """Analyze the current scene to learn real-world class usage patterns.
-
-    Scans every object and collects frequency data on:
-    - Which geometry/material/modifier/texmap classes are used and how often
-    - Common modifier stacks (e.g. "TurboSmooth | Symmetry" appears 12 times)
-    - Material-to-geometry associations (e.g. "PhysicalMaterial -> Editable Poly")
-    - Texture-to-material connections (e.g. "Bitmap -> PhysicalMaterial")
-
-    Use this to understand a scene's structure before making changes,
-    or to learn production conventions from real files.
-
-    Returns:
-        JSON with frequency-sorted pattern data across all categories.
-    """
+def _learn_scene_patterns() -> str:
+    """Analyze current scene for class usage patterns, modifier stacks, and material associations."""
     response = client.send_command("", cmd_type="native:learn_scene_patterns")
     return response.get("result", "{}")
 
 
-@mcp.tool()
-def watch_scene(
-    action: str = "status",
+def _watch_scene(
+    watch_action: str = "status",
     since: int = 0,
     limit: int = 100,
 ) -> str:
-    """Live scene event watcher — track what happens in 3ds Max in real-time.
-
-    Registers native SDK notification callbacks to capture scene events:
-    node created/deleted, selection changes, modifier added, material assigned,
-    file open, undo/redo, render start/end.
-
-    Events are buffered (up to 500) and can be polled via action="get".
-
-    Actions:
-        status: Check if watcher is active and how many events are buffered.
-        start: Start watching scene events.
-        stop: Stop watching (callbacks stay registered but events aren't captured).
-        get: Retrieve buffered events. Use since=<timestamp> for incremental polling.
-        clear: Clear the event buffer.
-
-    Args:
-        action: One of: status, start, stop, get, clear.
-        since: For action="get" — only return events after this timestamp.
-        limit: For action="get" — max events to return (default 100).
-
-    Returns:
-        JSON with watcher status and/or event list.
-    """
-    payload = {"action": action}
-    if action == "get":
+    """Live scene event watcher."""
+    payload = {"action": watch_action}
+    if watch_action == "get":
         payload["since"] = since
         payload["limit"] = limit
     response = client.send_command(json.dumps(payload), cmd_type="native:watch_scene")
     return response.get("result", "{}")
+
+
+# ── Unified tool ────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def manage_learning(
+    action: str,
+    name: str = "",
+    max_depth: int = 3,
+    pattern: str = "",
+    superclass: str = "",
+    limit: int = 100,
+    watch_action: str = "status",
+    since: int = 0,
+) -> str:
+    """SDK learning and introspection. Actions: walk_references, map_relationships, learn_patterns, watch.
+
+    Args:
+        action: "walk_references" | "map_relationships" | "learn_patterns" | "watch".
+        name: Object name (for walk_references).
+        max_depth: Max recursion depth (for walk_references, default 3, max 8).
+        pattern: Wildcard class filter (for map_relationships).
+        superclass: Superclass filter (for map_relationships).
+        limit: Max results (for map_relationships/watch, default 100).
+        watch_action: status|start|stop|get|clear (for watch).
+        since: Timestamp filter for watch get events.
+    """
+    if action == "walk_references":
+        return _walk_references(name, max_depth)
+    if action == "map_relationships":
+        return _map_class_relationships(pattern, superclass, limit)
+    if action == "learn_patterns":
+        return _learn_scene_patterns()
+    if action == "watch":
+        return _watch_scene(watch_action, since, limit)
+    return f"Unknown action: {action}. Use: walk_references, map_relationships, learn_patterns, watch"

--- a/src/tools/material_ops.py
+++ b/src/tools/material_ops.py
@@ -441,23 +441,13 @@ def assign_material(
     material_name: str = "",
     params: str = "",
 ) -> str:
-    """Create a material and assign it to one or more objects.
-
-    Use this when the user wants to apply a new material to objects — e.g.
-    "make the body chrome", "give it a glass material", "assign Arnold surface".
-    Creates the material, optionally sets initial parameters, and assigns it.
-    To modify an existing material's properties, use set_material_property instead.
+    """Create a material and assign it to objects.
 
     Args:
-        names: List of object names to assign the material to.
-        material_class: Material class name (e.g. "ai_standard_surface",
-                        "PhysicalMaterial", "StandardMaterial", "Multimaterial").
-        material_name: Optional name for the material. Auto-generated if empty.
-        params: Optional MAXScript parameters for creation
-                (e.g. "base_color:(color 200 50 50) metalness:1.0").
-
-    Returns:
-        Confirmation with material name and assigned object count.
+        names: Object names to assign the material to.
+        material_class: Material class (e.g. "ai_standard_surface", "PhysicalMaterial").
+        material_name: Display name for the material. Auto-generated if empty.
+        params: MAXScript creation params (e.g. "base_color:(color 200 50 50) metalness:1.0").
     """
     if client.native_available:
         payload = {
@@ -499,43 +489,13 @@ def assign_material(
     return response.get("result", "")
 
 
-@mcp.tool()
-def set_material_property(
+def _set_material_property(
     name: str,
     property: str,
     value: str,
     sub_material_index: int = 0,
 ) -> str:
-    """Set a property on an object's material (or sub-material).
-
-    Use this to change any material parameter — colors, floats, booleans,
-    texture map slots, or clearing maps. This is the write counterpart to
-    inspect_properties with target="material". Handles all material types
-    including Arnold (ai_standard_surface), Physical, Standard, and
-    Multi/Sub-Object (use sub_material_index to target a sub-material).
-
-    Common patterns:
-    - Set color: property="base_color" value="color 200 50 50"
-    - Set float: property="metalness" value="1.0"
-    - Set bool: property="thin_walled" value="true"
-    - Clear a texture map: property="base_color_shader" value="undefined"
-    - Assign a map by variable: property="specular_color_shader" value="thinFilm"
-      (where thinFilm was created via execute_maxscript)
-
-    Args:
-        name: The object name whose material to modify (e.g. "CC_Base_Body").
-        property: Material property name (e.g. "base_color", "metalness",
-                  "specular_roughness", "coat", "base_color_shader").
-                  Use inspect_properties with target="material" to discover names.
-        value: Value as a MAXScript expression (e.g. "1.0", "color 255 0 0",
-               "true", "undefined").
-        sub_material_index: For Multi/Sub-Object materials, 1-based index of
-                           the sub-material to modify. 0 = modify the top-level
-                           material directly (default).
-
-    Returns:
-        Confirmation with the property name and new value, or error message.
-    """
+    """Set a single property on an object's material or sub-material."""
     if client.native_available:
         payload = {
             "name": name,
@@ -581,38 +541,12 @@ def set_material_property(
     return response.get("result", "")
 
 
-@mcp.tool()
-def set_material_properties(
+def _set_material_properties(
     name: str,
     properties: dict[str, str],
     sub_material_index: int = 0,
 ) -> str:
-    """Set multiple properties on an object's material in a single call.
-
-    Use this when you need to change several material parameters at once —
-    e.g. setting up a chrome look (metalness, base_color, specular_roughness,
-    coat all in one call). Much more efficient than multiple set_material_property
-    calls. Each property-value pair is a MAXScript expression.
-
-    Common use cases:
-    - Chrome: {"metalness": "1.0", "base_color": "color 200 210 230",
-               "specular_roughness": "0.05", "coat": "0.8"}
-    - Glass: {"transmission": "0.9", "specular_roughness": "0.0",
-              "specular_IOR": "1.5", "thin_walled": "true"}
-    - Clear all maps: {"base_color_shader": "undefined",
-                       "specular_shader": "undefined",
-                       "subsurface_shader": "undefined"}
-
-    Args:
-        name: The object name whose material to modify.
-        properties: Dictionary of property names to MAXScript value expressions.
-                    e.g. {"metalness": "1.0", "base_color": "color 200 50 50"}
-        sub_material_index: For Multi/Sub-Object materials, 1-based index.
-                           0 = top-level material (default).
-
-    Returns:
-        Summary of all properties set and any errors encountered.
-    """
+    """Set multiple properties on an object's material in one call."""
     if client.native_available:
         payload = {
             "name": name,
@@ -685,26 +619,15 @@ def get_material_slots(
     slot_scope: str = "map",
     max_per_group: int = 15,
 ) -> str:
-    """Get compact material slot/property info without schema caches.
-
-    This is a token-efficient runtime inspector that categorizes material
-    properties into map/color/numeric/bool slots directly from 3ds Max.
-    Use this when an agent needs practical slot names before writing values.
-
-    Prefer slot_scope="map" (default) or "summary" over "all".
-    Using "all" with include_values=True on complex materials (Physical,
-    Arnold) returns 40+ params.
+    """Get categorized material slot/property names (map/color/numeric/bool).
 
     Args:
-        name: Object name whose material should be inspected.
-        sub_material_index: Multi/Sub slot index (1-based). 0 = top material.
-        include_values: Include truncated readback values for each slot.
-        max_slots: Hard cap on inspected properties to control response size.
+        name: Object name whose material to inspect.
+        sub_material_index: 1-based Multi/Sub slot index. 0 = top material.
+        include_values: Include current values for each slot.
+        max_slots: Max properties to inspect (default 40).
         slot_scope: "map" (default), "summary", or "all".
-        max_per_group: Max returned slots per category.
-
-    Returns:
-        Compact JSON with categorized slot names (and optional values).
+        max_per_group: Max slots per category (default 15).
     """
     if client.native_available:
         try:
@@ -955,42 +878,14 @@ def get_material_slots(
     return json.dumps(compact, separators=(",", ":"))
 
 
-@mcp.tool()
-def create_texture_map(
+def _create_texture_map(
     map_class: str,
     map_name: str = "",
     params: str = "",
     properties: dict[str, str] | None = None,
     global_var: str = "",
 ) -> str:
-    """Create a texture map and store it as a MAXScript global variable.
-
-    Use this when you need to create texture maps (OSLMap, Bitmaptexture,
-    ai_bump2d, tyBitmap, Noise, Checker, etc.) that will be wired into
-    material shader slots via set_material_property. The map is stored as
-    a MAXScript global so it can be referenced by name in later calls.
-
-    Common patterns:
-    - OSL map: map_class="OSLMap", params='', then set OSLPath via properties
-    - Bitmap: map_class="Bitmaptexture", properties={"fileName": '"C:/tex.png"'}
-    - Arnold bump: map_class="ai_bump2d", properties={"bump_height": "0.02"}
-    - Noise: map_class="Noise", properties={"size": "10.0"}
-
-    Args:
-        map_class: Texture map class name (e.g. "OSLMap", "Bitmaptexture",
-                   "ai_bump2d", "tyBitmap", "Noise", "Checker", "Gradient").
-        map_name: Optional display name for the map.
-        params: Optional MAXScript creation parameters.
-        properties: Optional dict of property names to MAXScript values to set
-                    after creation. Useful for OSLMap (set OSLPath first, then
-                    set exposed params in a follow-up call).
-        global_var: MAXScript global variable name to store the map as.
-                    If empty, auto-generated from map_name or map_class.
-                    Use this name in set_material_property value field to wire it.
-
-    Returns:
-        Confirmation with the global variable name to reference this map.
-    """
+    """Create a texture map and store it as a MAXScript global variable for later wiring."""
     if client.native_available:
         payload = {
             "map_class": map_class,
@@ -1052,26 +947,11 @@ def create_texture_map(
     return response.get("result", "")
 
 
-@mcp.tool()
-def set_texture_map_properties(
+def _set_texture_map_properties(
     global_var: str,
     properties: dict[str, str],
 ) -> str:
-    """Set properties on a texture map stored as a MAXScript global variable.
-
-    Use this after create_texture_map to configure map parameters — especially
-    useful for OSLMap where parameters are only exposed AFTER setting OSLPath.
-    Two-step OSL workflow: (1) create_texture_map with OSLPath, (2) this tool
-    to set the dynamically exposed shader parameters.
-
-    Args:
-        global_var: The global variable name from create_texture_map.
-        properties: Dict of property names to MAXScript value expressions.
-                    e.g. {"IrisSize": "0.4", "PupilColor": "color 1 1 1"}
-
-    Returns:
-        Summary of properties set and any errors.
-    """
+    """Set properties on a texture map stored as a MAXScript global variable."""
     if client.native_available:
         payload = json.dumps({"global_var": global_var, "properties": properties})
         response = client.send_command(payload, cmd_type="native:set_texture_map_properties")
@@ -1114,8 +994,7 @@ def set_texture_map_properties(
     return response.get("result", "")
 
 
-@mcp.tool()
-def set_sub_material(
+def _set_sub_material(
     name: str,
     sub_material_index: int,
     material_class: str = "",
@@ -1123,27 +1002,7 @@ def set_sub_material(
     params: str = "",
     source_index: int = 0,
 ) -> str:
-    """Create or assign a sub-material in a Multi/Sub-Object material slot.
-
-    Use this to populate individual slots of a Multimaterial — e.g. after
-    creating a Multimaterial with assign_material, fill each slot with the
-    correct shader type. Can create a new material at the slot, or copy
-    a reference from another slot (for shared sub-materials like L/R eyes).
-
-    Args:
-        name: Object name that has the Multimaterial assigned.
-        sub_material_index: 1-based slot index to set (e.g. 1, 2, 3, 4).
-        material_class: Material class to create (e.g. "ai_standard_surface",
-                        "PhysicalMaterial"). Leave empty if using source_index.
-        material_name: Optional name for the new sub-material.
-        params: Optional MAXScript creation parameters.
-        source_index: If > 0, copies the reference from this slot index instead
-                      of creating a new material. Useful for shared sub-materials
-                      (e.g. slot 3 = slot 1 for symmetric parts).
-
-    Returns:
-        Confirmation of the sub-material assignment.
-    """
+    """Create or copy a sub-material into a Multi/Sub-Object slot."""
     if client.native_available:
         payload = {
             "name": name,
@@ -1197,66 +1056,13 @@ def set_sub_material(
     return response.get("result", "")
 
 
-@mcp.tool()
-def write_osl_shader(
+def _write_osl_shader(
     shader_name: str,
     osl_code: str,
     global_var: str = "",
     properties: dict[str, str] | None = None,
 ) -> str:
-    """Write an OSL shader to disk and create an OSLMap from it.
-
-    Use this for procedural shading — write OSL code, auto-save to 3ds Max's
-    temp/osl_shaders/ directory, create an OSLMap that loads the shader, and
-    store it as a MAXScript global variable ready to wire into materials via
-    set_material_property.
-
-    The shader file is saved to: {3dsMax temp}/osl_shaders/{shader_name}.osl
-    After loading, the OSLMap exposes all shader parameters as properties.
-    Use the optional properties dict to set initial parameter values.
-
-    IMPORTANT — OSL rules for 3ds Max 2026:
-    - The shader function name MUST match shader_name exactly
-    - Use UNIQUE shader_name for each new shader (reusing a name may hit a stale cache)
-    - Property names get lowercased by OSLMap (use lowercase keys in properties dict)
-    - color * float multiplication IS valid (e.g. EdgeColor * Boost)
-    - All outputs must be typed: "output color result = 0" or "output float result = 0"
-    - Annotations [[ ]] are optional but valid: float Power = 3.0 [[ string label = "Power" ]]
-    - Standard OSL globals work: N, I, P, u, v, time, dPdu, dPdv
-    - Common functions: mix(), pow(), abs(), dot(), normalize(), noise(), clamp(), smoothstep()
-
-    Working example:
-        shader_name="FresnelGlow"
-        osl_code='''shader FresnelGlow(
-            color CoreColor = color(0.02, 0.02, 0.05),
-            color EdgeColor = color(0.2, 0.6, 1.0),
-            float Power = 3.0,
-            float Boost = 2.0,
-            output color result = 0
-        )
-        {
-            float d = dot(normalize(N), normalize(I));
-            float f = pow(1.0 - abs(d), Power);
-            result = mix(CoreColor, EdgeColor * Boost, f);
-        }'''
-        properties={"power": "4.0", "boost": "3.0"}
-
-    After creation, wire into a material:
-        set_material_property(name="MyObj", property="base_color_shader", value="FresnelGlow")
-
-    Args:
-        shader_name: Name for the shader file and OSLMap. MUST match the shader
-                     function name in osl_code. Use unique names to avoid cache issues.
-        osl_code: Complete OSL shader source code. Must include the shader
-                  function with typed parameters and output(s).
-        global_var: MAXScript global variable name. If empty, derived from
-                    shader_name. Use this name to reference the map later.
-        properties: Optional dict of shader parameter values to set after
-                    loading. Keys MUST be lowercase (e.g. {"power": "4.0"}).
-
-    Returns:
-        Confirmation with file path, global variable name, and compilation status.
-    """
+    """Write OSL shader to disk and create an OSLMap global variable."""
     if not global_var:
         global_var = "".join(c if c.isalnum() or c == "_" else "_" for c in shader_name)
         if global_var[0].isdigit():
@@ -1332,41 +1138,14 @@ def write_osl_shader(
     return response.get("result", "")
 
 
-@mcp.tool()
-def create_material_from_textures(
+def _create_material_from_textures(
     texture_folder: str,
     material_class: str = "",
     material_name: str = "",
     assign_to: StrList | None = None,
     custom_patterns: dict[str, list[str]] | None = None,
 ) -> str:
-    """Create a fully-wired PBR material from a folder of texture maps.
-
-    Point at a folder containing named texture files (e.g. *_basecolor.png,
-    *_roughness.png, *_normal.png) and this tool will auto-detect channels,
-    create the appropriate material for the current renderer, wire all maps
-    with correct color spaces, and optionally assign to objects.
-
-    Supports Arnold (ai_standard_surface), Physical Material, and Redshift.
-    Auto-detects the active renderer if material_class is not specified.
-    Handles compositing (diffuse+AO), inversion (gloss->rough), and
-    intermediate nodes (normal maps, bump2d).
-
-    Args:
-        texture_folder: Path to the folder containing texture files.
-        material_class: Force a specific material class ("ai_standard_surface",
-                        "PhysicalMaterial", "RS_Standard_Material").
-                        If empty, auto-detects from the current renderer.
-        material_name: Name for the created material. If empty, derived from
-                       the folder name.
-        assign_to: Optional list of object names to assign the material to.
-        custom_patterns: Optional dict overriding channel-to-suffix matching.
-                         Keys are channel names (e.g. "diffuse", "roughness"),
-                         values are lists of suffixes (e.g. ["_basecolor", "_albedo"]).
-
-    Returns:
-        Summary of created material, matched channels, and assignment status.
-    """
+    """Create a PBR material from a folder of texture maps with auto-channel detection."""
     # -- Step 1: Scan folder (Python-side) --
     files = _scan_texture_folder(texture_folder)
     if not files:
@@ -1578,8 +1357,7 @@ def _build_shell_maxscript(
     return "(\n    " + "\n    ".join(lines) + "\n)"
 
 
-@mcp.tool()
-def create_shell_material(
+def _create_shell_material(
     shell_name: str,
     render_material_name: str,
     base_color_path: str,
@@ -1588,34 +1366,7 @@ def create_shell_material(
     gltf_material_name: str = "",
     assign_to: StrList | None = None,
 ) -> str:
-    """Create a Shell Material with UberBitmap-based Arnold render slot and glTF export slot.
-
-    Builds a dual-pipeline material: Arnold ai_standard_surface for rendering
-    (originalMaterial, slot 0) and an existing glTF Material for export
-    (bakedMaterial, slot 1).
-
-    The Arnold material uses UberBitmap2 OSL maps with RGB channel splitting
-    via MultiOutputChannelTexmapToTexmap for packed ORM textures:
-    - BaseColor UberBitmap Col(RGB) × ORM R(AO) via ai_multiply → base_color
-    - ORM G → specular_roughness
-    - ORM B → metalness
-    - Optional: Normal UberBitmap → ai_normal_map → ai_bump2d → normal
-
-    Args:
-        shell_name: Name for the Shell Material (e.g. "m_mouse_shell").
-        render_material_name: Name for the Arnold material (e.g. "mouse_real").
-        base_color_path: Path to the BaseColor texture file.
-        orm_path: Path to the OcclusionRoughnessMetallic packed texture file.
-        normal_path: Optional path to the Normal map texture file.
-        gltf_material_name: Name of an existing glTF Material in scene to use
-                            as the baked/export slot. If empty, baked slot is left empty.
-        assign_to: Optional list of object names to assign the shell to.
-                   If empty but gltf_material_name is set, auto-assigns to all
-                   objects currently using that glTF material.
-
-    Returns:
-        JSON with shell_name, render_material, gltf_material, assigned_count, status.
-    """
+    """Create a Shell Material with Arnold render slot and glTF export slot."""
     if client.native_available:
         try:
             payload = json.dumps({
@@ -1652,3 +1403,80 @@ def create_shell_material(
 
     response = client.send_command(maxscript)
     return response.get("result", "{}")
+
+
+# ── Unified tool ────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def manage_material_ops(
+    action: str,
+    name: str = "",
+    property: str = "",
+    value: str = "",
+    sub_material_index: int = 0,
+    properties: dict[str, str] | None = None,
+    material_class: str = "",
+    material_name: str = "",
+    params: str = "",
+    source_index: int = 0,
+    map_class: str = "",
+    map_name: str = "",
+    global_var: str = "",
+    texture_folder: str = "",
+    assign_to: StrList | None = None,
+    custom_patterns: dict[str, list[str]] | None = None,
+    shader_name: str = "",
+    osl_code: str = "",
+    shell_name: str = "",
+    render_material_name: str = "",
+    base_color_path: str = "",
+    orm_path: str = "",
+    normal_path: str = "",
+    gltf_material_name: str = "",
+) -> str:
+    """Material operations. Actions: set_property, set_properties, set_sub, create_texture, set_texture_props, from_textures, create_shell, write_osl.
+
+    Args:
+        action: Operation to perform.
+        name: Object name (for set_property/set_properties/set_sub).
+        property: Property name (for set_property).
+        value: MAXScript value expression (for set_property).
+        sub_material_index: 1-based Multi/Sub slot (for set_property/set_properties/set_sub).
+        properties: Dict of property:value pairs (for set_properties/set_texture_props/write_osl).
+        material_class: Material class (for set_sub).
+        material_name: Material name (for set_sub/from_textures).
+        params: MAXScript creation params (for set_sub/create_texture).
+        source_index: Copy from this slot (for set_sub).
+        map_class: Texture map class (for create_texture).
+        map_name: Display name (for create_texture).
+        global_var: MAXScript global var name (for create_texture/set_texture_props/write_osl).
+        texture_folder: Path to texture folder (for from_textures).
+        assign_to: Object names to assign (for from_textures/create_shell).
+        custom_patterns: Channel pattern overrides (for from_textures).
+        shader_name: OSL shader name (for write_osl).
+        osl_code: OSL source code (for write_osl).
+        shell_name: Shell Material name (for create_shell).
+        render_material_name: Arnold material name (for create_shell).
+        base_color_path: BaseColor texture path (for create_shell).
+        orm_path: ORM texture path (for create_shell).
+        normal_path: Normal map path (for create_shell).
+        gltf_material_name: glTF material name for export slot (for create_shell).
+    """
+    if action == "set_property":
+        return _set_material_property(name, property, value, sub_material_index)
+    if action == "set_properties":
+        return _set_material_properties(name, properties or {}, sub_material_index)
+    if action == "set_sub":
+        return _set_sub_material(name, sub_material_index, material_class, material_name, params, source_index)
+    if action == "create_texture":
+        return _create_texture_map(map_class, map_name, params, properties, global_var)
+    if action == "set_texture_props":
+        return _set_texture_map_properties(global_var, properties or {})
+    if action == "from_textures":
+        return _create_material_from_textures(texture_folder, material_class, material_name, assign_to, custom_patterns)
+    if action == "create_shell":
+        return _create_shell_material(shell_name, render_material_name, base_color_path, orm_path, normal_path, gltf_material_name, assign_to)
+    if action == "write_osl":
+        return _write_osl_shader(shader_name, osl_code, global_var, properties)
+    return f"Unknown action: {action}. Use: set_property, set_properties, set_sub, create_texture, set_texture_props, from_textures, create_shell, write_osl"

--- a/src/tools/material_replace.py
+++ b/src/tools/material_replace.py
@@ -12,26 +12,15 @@ from ..coerce import DictList
 from src.helpers.maxscript import safe_string
 
 
-@mcp.tool()
-def replace_material(
+# ── Private helpers ─────────────────────────────────────────────────
+
+
+def _replace_material(
     source_material: str,
     target_material: str,
     preview: bool = False,
 ) -> str:
-    """Replace one material with another across all objects that use it.
-
-    Finds every object whose material name matches *target_material* and
-    reassigns it to the material named *source_material*.  The source
-    material must already exist on at least one object in the scene.
-
-    Args:
-        source_material: Name of the material to apply (must exist in scene).
-        target_material: Name of the material to replace / remove.
-        preview: If True, only list affected objects without making changes.
-
-    Returns:
-        JSON with affected object names, count, and status.
-    """
+    """Replace one material with another across all objects."""
     if client.native_available:
         payload = _json.dumps({"source_material": source_material, "target_material": target_material, "preview": preview})
         response = client.send_command(payload, cmd_type="native:replace_material")
@@ -108,25 +97,11 @@ def replace_material(
     return response.get("result", "{}")
 
 
-@mcp.tool()
-def batch_replace_materials(
+def _batch_replace_materials(
     replacements: DictList,
     preview: bool = False,
 ) -> str:
-    """Replace multiple materials in a single operation.
-
-    Each entry maps a source material (to keep) to a target material
-    (to replace).  Useful for unifying several split assignments at once.
-
-    Args:
-        replacements: List of dicts, each with:
-            - "source": name of the material to apply
-            - "target": name of the material to replace
-        preview: If True, only list affected objects without making changes.
-
-    Returns:
-        JSON with per-replacement results and an overall summary.
-    """
+    """Replace multiple materials in a single operation."""
     if client.native_available:
         payload = _json.dumps({"replacements": list(replacements), "preview": preview})
         response = client.send_command(payload, cmd_type="native:batch_replace_materials")
@@ -139,7 +114,7 @@ def batch_replace_materials(
         if not src or not tgt:
             results.append({"source": src, "target": tgt, "status": "skipped", "error": "missing source or target"})
             continue
-        raw = replace_material(source_material=src, target_material=tgt, preview=preview)
+        raw = _replace_material(source_material=src, target_material=tgt, preview=preview)
         try:
             results.append(_json.loads(raw))
         except _json.JSONDecodeError:
@@ -151,3 +126,30 @@ def batch_replace_materials(
         "total_replaced": total_replaced,
         "preview": preview,
     })
+
+
+# ── Unified tool ────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def manage_material_replace(
+    action: str,
+    source_material: str = "",
+    target_material: str = "",
+    preview: bool = False,
+    replacements: DictList | None = None,
+) -> str:
+    """Replace materials across objects. Actions: replace, batch_replace.
+
+    Args:
+        action: "replace" | "batch_replace".
+        source_material: Material to apply (for replace).
+        target_material: Material to replace (for replace).
+        preview: Only list affected objects without changes.
+        replacements: List of {"source": str, "target": str} (for batch_replace).
+    """
+    if action == "replace":
+        return _replace_material(source_material, target_material, preview)
+    if action == "batch_replace":
+        return _batch_replace_materials(replacements or [], preview)
+    return f"Unknown action: {action}. Use: replace, batch_replace"

--- a/src/tools/modifiers.py
+++ b/src/tools/modifiers.py
@@ -10,11 +10,9 @@ def add_modifier(name: str, modifier: str, params: str = "") -> str:
     """Add a modifier to an object.
 
     Args:
-        name: The object name (e.g. "Box001")
-        modifier: Modifier class name (e.g. "TurboSmooth", "Bend", "Shell", "Edit_Poly")
-        params: Optional MAXScript parameters (e.g. "iterations:2")
-
-    Returns confirmation or error.
+        name: Object name.
+        modifier: Modifier class (e.g. "TurboSmooth", "Bend").
+        params: Optional MAXScript params (e.g. "iterations:2").
     """
     if client.native_available:
         try:
@@ -43,16 +41,11 @@ def add_modifier(name: str, modifier: str, params: str = "") -> str:
     return response.get("result", "")
 
 
-@mcp.tool()
-def remove_modifier(name: str, modifier: str) -> str:
-    """Remove a modifier from an object by name.
+# ── Private helpers (merged tools) ──────────────────────────────────
 
-    Args:
-        name: The object name (e.g. "Box001")
-        modifier: The modifier name to remove (e.g. "TurboSmooth 1", "Bend 1")
 
-    Returns confirmation or error.
-    """
+def _remove_modifier(name: str, modifier: str) -> str:
+    """Remove a modifier from an object by name."""
     if client.native_available:
         try:
             payload = _json.dumps({"name": name, "modifier": modifier})
@@ -86,8 +79,7 @@ def remove_modifier(name: str, modifier: str) -> str:
     return response.get("result", "")
 
 
-@mcp.tool()
-def set_modifier_state(
+def _set_modifier_state(
     name: str,
     modifier_name: str = "",
     modifier_index: int = 0,
@@ -95,27 +87,7 @@ def set_modifier_state(
     enabled_in_views: Optional[bool] = None,
     enabled_in_renders: Optional[bool] = None,
 ) -> str:
-    """Set the enable state of a modifier with viewport/render granularity.
-
-    Use this instead of execute_maxscript when you need to toggle modifiers
-    on/off — e.g. disable TurboSmooth in viewport for performance but keep
-    it for render, or temporarily disable a Bend to see the base shape.
-
-    3ds Max modifiers have three independent enable flags:
-    - enabled: master on/off
-    - enabledInViews: active in viewport only
-    - enabledInRenders: active in renders only
-
-    Args:
-        name: The object name.
-        modifier_name: Modifier name to find (e.g. "TurboSmooth 1"). Ignored if modifier_index is set.
-        modifier_index: 1-based modifier stack index. Takes priority over modifier_name.
-        enabled: Set master enabled state.
-        enabled_in_views: Set viewport-only enabled state.
-        enabled_in_renders: Set render-only enabled state.
-
-    Returns confirmation.
-    """
+    """Set modifier enable state (master, viewport-only, render-only)."""
     if client.native_available:
         try:
             payload = {"name": name, "modifier_name": modifier_name, "modifier_index": modifier_index}
@@ -174,24 +146,11 @@ def set_modifier_state(
     return response.get("result", "")
 
 
-@mcp.tool()
-def collapse_modifier_stack(
+def _collapse_modifier_stack(
     name: str,
     to_index: int = 0,
 ) -> str:
-    """Collapse the modifier stack on an object.
-
-    Use this to bake modifiers into the mesh — e.g. before boolean operations,
-    exporting, or when the parametric stack is no longer needed. Converts to
-    Editable Mesh/Poly.
-
-    Args:
-        name: The object name.
-        to_index: If 0, collapses the entire stack. Otherwise, collapses
-                  down to the specified 1-based modifier index.
-
-    Returns confirmation.
-    """
+    """Collapse the modifier stack (bake to mesh)."""
     if client.native_available:
         try:
             payload = _json.dumps({"name": name, "to_index": to_index})
@@ -229,19 +188,8 @@ def collapse_modifier_stack(
     return response.get("result", "")
 
 
-@mcp.tool()
-def make_modifier_unique(name: str, modifier_index: int) -> str:
-    """Make an instanced modifier unique (de-instance it).
-
-    Use this when multiple objects share the same modifier instance and you
-    need to change one without affecting the others.
-
-    Args:
-        name: The object name.
-        modifier_index: 1-based modifier stack index.
-
-    Returns confirmation.
-    """
+def _make_modifier_unique(name: str, modifier_index: int) -> str:
+    """Make an instanced modifier unique (de-instance)."""
     if client.native_available:
         try:
             payload = _json.dumps({"name": name, "modifier_index": modifier_index})
@@ -269,29 +217,14 @@ def make_modifier_unique(name: str, modifier_index: int) -> str:
     return response.get("result", "")
 
 
-@mcp.tool()
-def batch_modify(
+def _batch_modify(
     modifier_class: str,
     property_name: str,
     property_value: str,
     names: Optional[StrList] = None,
     selection_only: bool = False,
 ) -> str:
-    """Batch-set a property on all modifiers of a given class across multiple objects.
-
-    Use this for scene-wide modifier changes — e.g. "set all TurboSmooth
-    iterations to 0" or "disable all Bend modifiers". Much faster and safer
-    than looping via execute_maxscript. Wraps in disableSceneRedraw and undo.
-
-    Args:
-        modifier_class: Class name to match (e.g. "TurboSmooth", "Bend").
-        property_name: Property to set (e.g. "iterations", "angle").
-        property_value: Value as MAXScript expression (e.g. "3", "45.0", "true").
-        names: Optional list of specific object names. If empty, uses all or selection.
-        selection_only: If True and names is empty, only process selected objects.
-
-    Returns count of modified modifiers.
-    """
+    """Batch-set a property on all modifiers of a given class across objects."""
     if client.native_available:
         try:
             payload = {
@@ -341,3 +274,54 @@ def batch_modify(
     )"""
     response = client.send_command(maxscript)
     return response.get("result", "")
+
+
+# ── Unified tool ────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def manage_modifiers(
+    action: str,
+    name: str = "",
+    modifier: str = "",
+    modifier_name: str = "",
+    modifier_index: int = 0,
+    to_index: int = 0,
+    enabled: Optional[bool] = None,
+    enabled_in_views: Optional[bool] = None,
+    enabled_in_renders: Optional[bool] = None,
+    modifier_class: str = "",
+    property_name: str = "",
+    property_value: str = "",
+    names: Optional[StrList] = None,
+    selection_only: bool = False,
+) -> str:
+    """Modifier stack operations. Actions: remove, set_state, collapse, make_unique, batch.
+
+    Args:
+        action: "remove"|"set_state"|"collapse"|"make_unique"|"batch".
+        name: Object name.
+        modifier: Modifier name to remove (for remove).
+        modifier_name: Modifier name for set_state (ignored if modifier_index set).
+        modifier_index: 1-based stack index (for set_state, make_unique).
+        to_index: Collapse to this index; 0=entire stack (for collapse).
+        enabled: Master on/off (for set_state).
+        enabled_in_views: Viewport state (for set_state).
+        enabled_in_renders: Render state (for set_state).
+        modifier_class: Class to match (for batch, e.g. "TurboSmooth").
+        property_name: Property to set (for batch).
+        property_value: Value as MAXScript expression (for batch).
+        names: Specific object names (for batch).
+        selection_only: Only selected objects (for batch).
+    """
+    if action == "remove":
+        return _remove_modifier(name, modifier)
+    if action == "set_state":
+        return _set_modifier_state(name, modifier_name, modifier_index, enabled, enabled_in_views, enabled_in_renders)
+    if action == "collapse":
+        return _collapse_modifier_stack(name, to_index)
+    if action == "make_unique":
+        return _make_modifier_unique(name, modifier_index)
+    if action == "batch":
+        return _batch_modify(modifier_class, property_name, property_value, names, selection_only)
+    return f"Unknown action: {action}. Use: remove, set_state, collapse, make_unique, batch"

--- a/src/tools/objects.py
+++ b/src/tools/objects.py
@@ -2,6 +2,7 @@ import json as _json
 
 from ..server import mcp, client
 from ..coerce import StrList
+from ..safety import wrap_with_safety
 from src.helpers.maxscript import safe_string
 
 
@@ -112,7 +113,7 @@ def delete_objects(names: StrList) -> str:
         try:
             params = _json.dumps({"names": names})
             response = client.send_command(params, cmd_type="native:delete_objects")
-            return response.get("result", "")
+            return wrap_with_safety("delete_objects", response.get("result", ""))
         except RuntimeError:
             pass
 
@@ -139,4 +140,4 @@ def delete_objects(names: StrList) -> str:
         result
     )"""
     response = client.send_command(maxscript)
-    return response.get("result", "")
+    return wrap_with_safety("delete_objects", response.get("result", ""))

--- a/src/tools/objects.py
+++ b/src/tools/objects.py
@@ -6,105 +6,13 @@ from src.helpers.maxscript import safe_string
 
 
 @mcp.tool()
-def get_object_properties(name: str) -> str:
-    """Get detailed properties of a named object in the 3ds Max scene.
-
-    Args:
-        name: The object name (e.g. "Box001")
-
-    Returns properties including transform, material, and modifier stack.
-    """
-    if client.native_available:
-        try:
-            params = _json.dumps({"name": name})
-            response = client.send_command(params, cmd_type="native:get_object_properties")
-            return response.get("result", "{}")
-        except RuntimeError:
-            pass
-
-    # ── MAXScript fallback (TCP) ──────────────────────────────────
-    safe = safe_string(name)
-    maxscript = f"""(
-        local obj = getNodeByName "{safe}"
-        if obj != undefined then (
-            local posStr = "[" + (obj.pos.x as string) + "," + \
-                           (obj.pos.y as string) + "," + \
-                           (obj.pos.z as string) + "]"
-            local rotStr = "[" + (obj.rotation.x as string) + "," + \
-                           (obj.rotation.y as string) + "," + \
-                           (obj.rotation.z as string) + "]"
-            local scaleStr = "[" + (obj.scale.x as string) + "," + \
-                             (obj.scale.y as string) + "," + \
-                             (obj.scale.z as string) + "]"
-            local matName = if obj.material != undefined then obj.material.name else "none"
-            local modArr = for m in obj.modifiers collect ("\\\"" + m.name + "\\\"")
-            local modStr = "["
-            for i = 1 to modArr.count do (
-                if i > 1 do modStr += ","
-                modStr += modArr[i]
-            )
-            modStr += "]"
-            local parentName = if obj.parent != undefined then obj.parent.name else ""
-            local parentField = if parentName == "" then "null" else ("\\\"" + parentName + "\\\"")
-            local childArr = for c in obj.children collect ("\\\"" + c.name + "\\\"")
-            local childStr = "["
-            for i = 1 to childArr.count do (
-                if i > 1 do childStr += ","
-                childStr += childArr[i]
-            )
-            childStr += "]"
-            local numVStr = "null"
-            local numFStr = "null"
-            try (
-                local snapMesh = snapshotAsMesh obj
-                numVStr = snapMesh.numVerts as string
-                numFStr = snapMesh.numFaces as string
-                delete snapMesh
-            ) catch ()
-            local wcStr = "[" + (obj.wirecolor.r as string) + "," + (obj.wirecolor.g as string) + "," + (obj.wirecolor.b as string) + "]"
-            local bbMin = obj.min
-            local bbMax = obj.max
-            local dims = bbMax - bbMin
-            local dimsStr = "[" + (dims.x as string) + "," + (dims.y as string) + "," + (dims.z as string) + "]"
-            "{{" + \
-                "\\\"name\\\":\\\"" + obj.name + "\\\"," + \
-                "\\\"class\\\":\\\"" + ((classOf obj) as string) + "\\\"," + \
-                "\\\"superclass\\\":\\\"" + ((superClassOf obj) as string) + "\\\"," + \
-                "\\\"position\\\":" + posStr + "," + \
-                "\\\"rotation\\\":" + rotStr + "," + \
-                "\\\"scale\\\":" + scaleStr + "," + \
-                "\\\"parent\\\":" + parentField + "," + \
-                "\\\"children\\\":" + childStr + "," + \
-                "\\\"numVerts\\\":" + numVStr + "," + \
-                "\\\"numFaces\\\":" + numFStr + "," + \
-                "\\\"wirecolor\\\":" + wcStr + "," + \
-                "\\\"layer\\\":\\\"" + obj.layer.name + "\\\"," + \
-                "\\\"dimensions\\\":" + dimsStr + "," + \
-                "\\\"material\\\":\\\"" + matName + "\\\"," + \
-                "\\\"modifiers\\\":" + modStr + \
-            "}}"
-        ) else (
-            "Object not found: {safe}"
-        )
-    )"""
-    response = client.send_command(maxscript)
-    return response.get("result", "")
-
-
-@mcp.tool()
 def set_object_property(name: str, property: str, value: str) -> str:
-    """Set a property on a named object in the 3ds Max scene.
-
-    If unsure of exact property names, call get_object_properties or
-    inspect_object first. Property names vary by class (e.g. Cylinder has
-    "radius" not "radius1", Cone has "radius1"/"radius2").
+    """Set a property on a scene object. Use inspect_properties first if unsure of names.
 
     Args:
-        name: The object name (e.g. "Box001")
-        property: The property to set (e.g. "pos", "wirecolor", "height")
-        value: The value as a MAXScript expression (e.g. "[10,20,30]", "red", "50")
-
-    Returns confirmation or error message.
+        name: Object name.
+        property: Property to set (e.g. "pos", "height").
+        value: Value as MAXScript expression (e.g. "[10,20,30]", "50").
     """
     if client.native_available:
         try:
@@ -159,14 +67,12 @@ _TYPE_DEFAULTS = {
 
 @mcp.tool()
 def create_object(type: str, name: str = "", params: str = "") -> str:
-    """Create a new object in the 3ds Max scene.
+    """Create a new object in the scene.
 
     Args:
-        type: The object type (e.g. "Box", "Sphere", "Cylinder", "Plane", "Teapot")
-        name: Optional name for the object
-        params: Optional MAXScript parameters (e.g. "radius:25 pos:[0,0,50]")
-
-    Returns the name of the created object.
+        type: Object type (e.g. "Box", "Sphere", "Cylinder").
+        name: Optional object name.
+        params: Optional MAXScript params (e.g. "radius:25 pos:[0,0,50]").
     """
     # Apply sensible defaults when no params given — SDK defaults are all zeros
     if not params:
@@ -197,12 +103,10 @@ def create_object(type: str, name: str = "", params: str = "") -> str:
 
 @mcp.tool()
 def delete_objects(names: StrList) -> str:
-    """Delete objects from the 3ds Max scene by name.
+    """Delete objects by name.
 
     Args:
         names: List of object names to delete.
-
-    Returns summary of deleted and not found objects.
     """
     if client.native_available:
         try:

--- a/src/tools/organize.py
+++ b/src/tools/organize.py
@@ -45,42 +45,20 @@ def manage_layers(
     primaryVisibility: bool | None = None,
     secondaryVisibility: bool | None = None,
 ) -> str:
-    """Manage scene layers — create, delete, list, set properties, move objects.
-
-    All operations run through pure C++ SDK (ILayerManager). Requires native bridge.
-
-    Actions:
-        list: List all layers with properties and object counts.
-        create: Create a new layer. Params: name, color, hidden, frozen, renderable, parent.
-        delete: Delete a layer by name (must be empty and not default).
-        set_current: Set the active layer by name.
-        set_properties: Set layer properties. Params: name + any of hidden, frozen,
-                        renderable, color, rename, boxMode, castShadows, rcvShadows.
-        add_objects: Move objects to a layer. Params: layer (target), names or pattern.
-        select_objects: Select all objects on a layer. Params: name.
+    """Manage scene layers (C++ SDK). Actions: list, create, delete, set_current, set_properties, add_objects, select_objects.
 
     Args:
-        action: One of: list, create, delete, set_current, set_properties, add_objects, select_objects.
-        name: Layer name (used by most actions).
-        names: Object names (for add_objects).
-        pattern: Wildcard pattern to match object names (for add_objects). E.g. "Metal_Sigil_*".
-        layer: Target layer name (for add_objects).
-        color: RGB color [r, g, b] 0-255.
-        hidden: Hide the layer.
-        frozen: Freeze the layer.
-        renderable: Make layer renderable.
-        parent: Parent layer name (for create).
-        rename: New name (for set_properties).
-        boxMode: Display objects as boxes.
-        castShadows: Cast shadows.
-        rcvShadows: Receive shadows.
-        xRayMtl: Enable X-Ray material display.
-        backCull: Enable backface culling.
-        allEdges: Show all edges.
-        vertTicks: Show vertex ticks.
-        trajectory: Show trajectories.
-        primaryVisibility: Primary visibility flag.
-        secondaryVisibility: Secondary visibility flag.
+        action: list | create | delete | set_current | set_properties | add_objects | select_objects.
+        name: Layer name (most actions).
+        names: Object names (add_objects).
+        pattern: Wildcard for object names (add_objects).
+        layer: Target layer (add_objects).
+        color: RGB [r,g,b] 0-255.
+        hidden/frozen/renderable: Layer visibility flags.
+        parent: Parent layer (create).
+        rename: New name (set_properties).
+        boxMode/castShadows/rcvShadows/xRayMtl/backCull/allEdges/vertTicks/trajectory: Display flags.
+        primaryVisibility/secondaryVisibility: Render visibility flags.
     """
     # Resolve pattern to names for add_objects
     if action == "add_objects" and pattern and not names:
@@ -139,24 +117,13 @@ def manage_groups(
     names: StrList | None = None,
     group: str = "",
 ) -> str:
-    """Manage object groups — create, ungroup, open, close, attach, detach.
-
-    All operations run through pure C++ SDK (Interface::GroupNodes). Requires native bridge.
-
-    Actions:
-        list: List all groups with members.
-        create: Create a new group from objects. Params: names (objects to group), name (optional group name).
-        ungroup: Dissolve a group. Params: name (group head name).
-        open: Open a group for editing. Params: name.
-        close: Close an open group. Params: name.
-        attach: Add objects to existing group. Params: group (target), names (objects to add).
-        detach: Remove objects from their group. Params: names (objects to detach).
+    """Manage object groups (C++ SDK). Actions: list, create, ungroup, open, close, attach, detach.
 
     Args:
-        action: One of: list, create, ungroup, open, close, attach, detach.
-        name: Group name (for create, ungroup, open, close).
-        names: Object names (for create, attach, detach).
-        group: Target group name (for attach).
+        action: list | create | ungroup | open | close | attach | detach.
+        name: Group name.
+        names: Object names (create/attach/detach).
+        group: Target group (attach).
     """
     payload = {"action": action}
     if name:
@@ -176,21 +143,12 @@ def manage_selection_sets(
     name: str = "",
     names: StrList | None = None,
 ) -> str:
-    """Manage named selection sets — create, delete, list, select, replace.
-
-    All operations run through pure C++ SDK (INamedSelectionSetManager). Requires native bridge.
-
-    Actions:
-        list: List all named selection sets with members.
-        create: Create a new selection set. Params: name (set name), names (object names).
-        delete: Delete a selection set by name.
-        select: Select all objects in a set (replaces current selection).
-        replace: Replace a set's members. Params: name, names (new members).
+    """Manage named selection sets (C++ SDK). Actions: list, create, delete, select, replace.
 
     Args:
-        action: One of: list, create, delete, select, replace.
+        action: list | create | delete | select | replace.
         name: Selection set name.
-        names: Object names (for create, replace).
+        names: Object names (create/replace).
     """
     payload = {"action": action}
     if name:

--- a/src/tools/plugins.py
+++ b/src/tools/plugins.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any
+from typing import Any, Optional
 
 from src.helpers.maxscript import safe_string
 
@@ -807,15 +807,16 @@ def _build_manifest(plugin_name: str) -> dict[str, Any]:
     }
 
 
-@mcp.tool()
-def list_plugin_classes(
+# ── Private helpers for each action ──────────────────────────────
+
+
+def _list_classes(
     plugin_name: str = "",
     superclass: str = "",
     limit: int = 200,
 ) -> str:
     """List classes likely tied to a plugin or superclass family."""
     if client.native_available and not plugin_name:
-        # Pure SDK path for superclass-only enumeration
         payload = json.dumps({"superclass": superclass or "all"})
         response = client.send_command(payload, cmd_type="native:list_plugin_classes")
         return response.get("result", "")
@@ -834,8 +835,7 @@ def list_plugin_classes(
     })
 
 
-@mcp.tool()
-def discover_plugin_surface(
+def _discover_surface(
     plugin_name: str = "",
     class_limit: int = 100,
 ) -> str:
@@ -905,8 +905,7 @@ def discover_plugin_surface(
     })
 
 
-@mcp.tool()
-def inspect_plugin_class(
+def _inspect_class(
     class_name: str,
     include_methods: bool = True,
     include_properties: bool = True,
@@ -946,10 +945,9 @@ def inspect_plugin_class(
     })
 
 
-@mcp.tool()
-def inspect_plugin_constructor(class_name: str) -> str:
+def _inspect_constructor(class_name: str) -> str:
     """Return likely creation notes for a plugin class."""
-    inspected = _load_json(inspect_plugin_class(class_name, include_methods=False, include_properties=False), {})
+    inspected = _load_json(_inspect_class(class_name, include_methods=False, include_properties=False), {})
     if "error" in inspected:
         return json.dumps(inspected)
 
@@ -1053,8 +1051,7 @@ def _summarize_property_dump(property_dump: dict[str, Any], plugin_name: str, li
     }
 
 
-@mcp.tool()
-def inspect_plugin_instance(name: str, detail: str = "normal") -> str:
+def _inspect_instance(name: str, detail: str = "normal") -> str:
     """Inspect a live scene instance with plugin-aware summarization."""
     from .inspect import inspect_object, inspect_properties
 
@@ -1113,33 +1110,183 @@ def inspect_plugin_instance(name: str, detail: str = "normal") -> str:
     return json.dumps(result)
 
 
-@mcp.tool()
-def get_plugin_manifest(plugin_name: str) -> str:
+def _get_manifest(plugin_name: str) -> str:
     """Return a structured plugin manifest derived from live runtime data plus curated hints."""
     return json.dumps(_build_manifest(plugin_name))
 
 
-@mcp.tool()
-def refresh_plugin_manifest(plugin_name: str) -> str:
-    """Refresh and return the plugin manifest.
-
-    This currently rebuilds the manifest from live runtime data on every call.
-    """
+def _refresh_manifest(plugin_name: str) -> str:
+    """Rebuild and return the plugin manifest from live runtime data."""
     manifest = _build_manifest(plugin_name)
     manifest["refreshed"] = True
     return json.dumps(manifest)
 
 
+def _discover_classes(
+    superclass: str = "",
+    pattern: str = "",
+    limit: int = 100,
+) -> str:
+    """Enumerate all registered classes via native C++ SDK."""
+    payload = {}
+    if superclass:
+        payload["superclass"] = superclass
+    if pattern:
+        payload["pattern"] = pattern
+    if limit != 500:
+        payload["limit"] = limit
+    response = client.send_command(
+        json.dumps(payload) if payload else "",
+        cmd_type="native:discover_classes",
+    )
+    return response.get("result", "{}")
+
+
+def _introspect_class(class_name: str) -> str:
+    """Deep C++ SDK class introspection with _blocked_osl check."""
+    blocked = {"oslmap", "osl_map", "osl"}
+    if class_name.strip().lower() in blocked:
+        return json.dumps({"error": "OSLMap has dynamic params that produce unbounded output. Use introspect_osl instead.", "redirect": "introspect_osl"})
+    payload = json.dumps({"class_name": class_name})
+    response = client.send_command(payload, cmd_type="native:introspect_class")
+    return response.get("result", "{}")
+
+
+def _introspect_instance(
+    name: str,
+    include_subanims: bool = False,
+    subanim_depth: int = 2,
+) -> str:
+    """Deep C++ SDK introspection of a live scene object."""
+    payload = {"name": name}
+    if include_subanims:
+        payload["include_subanims"] = True
+    if subanim_depth != 3:
+        payload["subanim_depth"] = subanim_depth
+    response = client.send_command(
+        json.dumps(payload),
+        cmd_type="native:introspect_instance",
+    )
+    return response.get("result", "{}")
+
+
+# ── Unified tool ─────────────────────────────────────────────────
+
+
+@mcp.tool()
+def manage_plugins(
+    action: str,
+    plugin_name: Optional[str] = None,
+    class_name: Optional[str] = None,
+    name: Optional[str] = None,
+    superclass: Optional[str] = None,
+    pattern: Optional[str] = None,
+    detail: Optional[str] = None,
+    include_methods: Optional[bool] = None,
+    include_properties: Optional[bool] = None,
+    include_subanims: Optional[bool] = None,
+    subanim_depth: Optional[int] = None,
+    limit: Optional[int] = None,
+    class_limit: Optional[int] = None,
+) -> str:
+    """Plugin discovery, inspection, and manifest operations.
+
+    Actions: discover_surface, manifest, list_classes, refresh_manifest,
+    inspect_class, inspect_constructor, inspect_instance, discover_classes,
+    introspect_class, introspect_instance.
+    """
+    if action == "discover_surface":
+        return _discover_surface(
+            plugin_name=plugin_name or "",
+            class_limit=class_limit if class_limit is not None else 100,
+        )
+
+    if action == "manifest":
+        if not plugin_name:
+            return json.dumps({"error": "plugin_name is required for action 'manifest'"})
+        return _get_manifest(plugin_name)
+
+    if action == "list_classes":
+        return _list_classes(
+            plugin_name=plugin_name or "",
+            superclass=superclass or "",
+            limit=limit if limit is not None else 200,
+        )
+
+    if action == "refresh_manifest":
+        if not plugin_name:
+            return json.dumps({"error": "plugin_name is required for action 'refresh_manifest'"})
+        return _refresh_manifest(plugin_name)
+
+    if action == "inspect_class":
+        effective_class = class_name or plugin_name
+        if not effective_class:
+            return json.dumps({"error": "class_name is required for action 'inspect_class'"})
+        return _inspect_class(
+            class_name=effective_class,
+            include_methods=include_methods if include_methods is not None else True,
+            include_properties=include_properties if include_properties is not None else True,
+        )
+
+    if action == "inspect_constructor":
+        effective_class = class_name or plugin_name
+        if not effective_class:
+            return json.dumps({"error": "class_name is required for action 'inspect_constructor'"})
+        return _inspect_constructor(effective_class)
+
+    if action == "inspect_instance":
+        effective_name = name or plugin_name
+        if not effective_name:
+            return json.dumps({"error": "name is required for action 'inspect_instance'"})
+        return _inspect_instance(
+            name=effective_name,
+            detail=detail or "normal",
+        )
+
+    if action == "discover_classes":
+        return _discover_classes(
+            superclass=superclass or "",
+            pattern=pattern or "",
+            limit=limit if limit is not None else 100,
+        )
+
+    if action == "introspect_class":
+        effective_class = class_name or plugin_name
+        if not effective_class:
+            return json.dumps({"error": "class_name is required for action 'introspect_class'"})
+        return _introspect_class(effective_class)
+
+    if action == "introspect_instance":
+        effective_name = name or plugin_name
+        if not effective_name:
+            return json.dumps({"error": "name is required for action 'introspect_instance'"})
+        return _introspect_instance(
+            name=effective_name,
+            include_subanims=include_subanims if include_subanims is not None else False,
+            subanim_depth=subanim_depth if subanim_depth is not None else 2,
+        )
+
+    valid_actions = [
+        "discover_surface", "manifest", "list_classes", "refresh_manifest",
+        "inspect_class", "inspect_constructor", "inspect_instance",
+        "discover_classes", "introspect_class", "introspect_instance",
+    ]
+    return json.dumps({"error": f"Unknown action: {action}", "valid_actions": valid_actions})
+
+
+# ── MCP Resources (unchanged) ───────────────────────────────────
+
+
 @mcp.resource(PLUGIN_INDEX_RESOURCE_URI, name="Plugin Index", mime_type="application/json")
 def plugin_index_resource() -> str:
     """Installed plugin family summary as an MCP resource."""
-    return discover_plugin_surface()
+    return _discover_surface()
 
 
 @mcp.resource(PLUGIN_MANIFEST_RESOURCE_URI, name="Plugin Manifest", mime_type="application/json")
 def plugin_manifest_resource(plugin_name: str) -> str:
     """Per-plugin manifest as an MCP template resource."""
-    return get_plugin_manifest(plugin_name)
+    return _get_manifest(plugin_name)
 
 
 @mcp.resource(PLUGIN_GUIDE_RESOURCE_URI, name="Plugin Guide", mime_type="text/markdown")
@@ -1158,106 +1305,6 @@ def plugin_recipes_resource(plugin_name: str) -> str:
 def plugin_gotchas_resource(plugin_name: str) -> str:
     """Per-plugin gotchas as an MCP template resource."""
     return _plugin_gotchas_markdown(plugin_name)
-
-
-# ── Deep C++ SDK introspection tools ─────────────────────────────
-
-@mcp.tool()
-def discover_plugin_classes(
-    superclass: str = "",
-    pattern: str = "",
-    limit: int = 500,
-) -> str:
-    """Enumerate ALL registered classes in 3ds Max's DLL directory via native C++ SDK.
-
-    Scans every loaded plugin DLL and returns class metadata. Much faster and
-    more complete than MAXScript's showClass — covers classes that MAXScript
-    cannot see.
-
-    Args:
-        superclass: Filter by superclass: "geometry", "modifier", "material",
-                    "texturemap", "helper", "light", "camera", "shape", "spacewarp".
-                    Empty = all superclasses.
-        pattern: Wildcard name filter (e.g. "Forest*", "*Vray*"). Empty = all.
-        limit: Max classes to return (default 500).
-    """
-    payload = {}
-    if superclass:
-        payload["superclass"] = superclass
-    if pattern:
-        payload["pattern"] = pattern
-    if limit != 500:
-        payload["limit"] = limit
-    response = client.send_command(
-        json.dumps(payload) if payload else "",
-        cmd_type="native:discover_classes",
-    )
-    return response.get("result", "{}")
-
-
-@mcp.tool()
-def introspect_class(
-    class_name: str,
-) -> str:
-    """Deep C++ SDK introspection of a class — returns the COMPLETE API surface.
-
-    Enumerates all ParamBlock2 parameters (names, types, defaults, ranges,
-    animatable flags) and all FPInterface functions and properties directly
-    from the class descriptor. Works on ANY class — built-in or third-party plugin.
-
-    This goes deeper than inspect_plugin_class (MAXScript reflection). Use it
-    when you need parameter defaults, ranges, function signatures, or when
-    MAXScript reflection is incomplete.
-
-    Requires the native C++ bridge plugin.
-
-    For OSLMap / OSL classes, use introspect_osl instead — OSLMap has dynamic
-    params that produce unbounded output through the C++ path.
-
-    Args:
-        class_name: The class to introspect (e.g. "TurboSmooth", "Forest_Pro",
-                    "PhysicalMaterial", "tyFlow").
-    """
-    blocked = {"oslmap", "osl_map", "osl"}
-    if class_name.strip().lower() in blocked:
-        return json.dumps({"error": f"OSLMap has dynamic params that produce unbounded output. Use introspect_osl instead.", "redirect": "introspect_osl"})
-    payload = json.dumps({"class_name": class_name})
-    response = client.send_command(payload, cmd_type="native:introspect_class")
-    return response.get("result", "{}")
-
-
-@mcp.tool()
-def introspect_instance(
-    name: str,
-    include_subanims: bool = False,
-    subanim_depth: int = 3,
-) -> str:
-    """Deep C++ SDK introspection of a live scene object with actual values.
-
-    Reads all ParamBlock2 parameters with their CURRENT values, all FPInterface
-    methods and properties, the modifier stack with per-modifier params, material
-    params, and optionally the full SubAnim tree.
-
-    Goes deeper than inspect_plugin_instance. Use when you need to see parameter
-    values that MAXScript's getPropNames/showProperties cannot reach.
-
-    Requires the native C++ bridge plugin.
-
-    Args:
-        name: The scene object name to inspect.
-        include_subanims: Include the SubAnim hierarchy tree (can be large).
-        subanim_depth: Max depth for SubAnim tree traversal (default 3).
-    """
-    payload = {"name": name}
-    if include_subanims:
-        payload["include_subanims"] = True
-    if subanim_depth != 3:
-        payload["subanim_depth"] = subanim_depth
-    response = client.send_command(
-        json.dumps(payload),
-        cmd_type="native:introspect_instance",
-    )
-    return response.get("result", "{}")
 
 
 # Imported lazily to avoid circular imports at module load time.

--- a/src/tools/scattering.py
+++ b/src/tools/scattering.py
@@ -36,37 +36,22 @@ def scatter_forest_pack(
     viewport_mode: int = 2,
     render_mode: int = 0,
 ) -> str:
-    """Create a Forest Pack scatter object and wire surfaces + source geometry.
-
-    This uses Forest Pack's native parameter arrays (`surflist`, `cobjlist`,
-    `namelist`, `problist`, `geomlist`) so it works in a fully procedural way
-    without opening plugin UIs.
+    """Create a Forest Pack scatter with surfaces and source geometry.
 
     Args:
-        surfaces: Distribution surface object names.
+        surfaces: Distribution surface names.
         geometry: Source object names to scatter.
-        probabilities: Optional per-source weights. Must match `geometry` count.
-            Defaults to equal weights.
-        density: Forest Pack max density value.
+        probabilities: Per-source weights (must match geometry count).
+        density: Max density value.
         seed: Random seed.
-        scale_min: Uniform min scale percent.
-        scale_max: Uniform max scale percent.
-        z_rotation_min: Minimum Z random rotation in degrees.
-        z_rotation_max: Maximum Z random rotation in degrees.
-        source_width_cm: Source width in centimeters (explicit world units).
-        source_height_cm: Source height in centimeters (explicit world units).
-        icon_size_cm: Forest icon size in centimeters (explicit world units).
-        density_units_x_cm: Density map size X in centimeters (explicit world units).
-        density_units_y_cm: Density map size Y in centimeters (explicit world units).
-        facing_mode: Forest facing direction.
-            0 = surface normal (good for sprinkles),
-            1 = up/world-aligned (good for trees).
+        scale_min/scale_max: Uniform scale percent range.
+        z_rotation_min/z_rotation_max: Z rotation range in degrees.
+        source_width_cm/source_height_cm: Source size in cm.
+        icon_size_cm: Forest icon size in cm.
+        density_units_x_cm/density_units_y_cm: Density map size in cm.
+        facing_mode: 0 = surface normal, 1 = world up.
         name: Forest object name.
-        viewport_mode: Forest `vmesh` mode (integer enum).
-        render_mode: Forest `rmesh` mode (integer enum).
-
-    Returns:
-        JSON string summary or JSON error payload.
+        viewport_mode/render_mode: Forest display mode enums.
     """
     if not surfaces:
         raise ValueError("surfaces must contain at least one object name.")

--- a/src/tools/scene_manage.py
+++ b/src/tools/scene_manage.py
@@ -1,5 +1,6 @@
 import json as _json
 from ..server import mcp, client
+from ..safety import wrap_with_safety
 
 
 @mcp.tool()
@@ -21,7 +22,7 @@ def manage_scene(action: str) -> str:
     if client.native_available:
         payload = _json.dumps({"action": action})
         response = client.send_command(payload, cmd_type="native:manage_scene")
-        return response.get("result", "")
+        return wrap_with_safety("manage_scene", response.get("result", ""), action=action)
 
     if action == "hold":
         maxscript = """(
@@ -71,4 +72,4 @@ def manage_scene(action: str) -> str:
         return f"Unknown action: {action}. Use hold, fetch, reset, save, or info."
 
     response = client.send_command(maxscript)
-    return response.get("result", "")
+    return wrap_with_safety("manage_scene", response.get("result", ""), action=action)

--- a/src/tools/scene_query.py
+++ b/src/tools/scene_query.py
@@ -16,28 +16,11 @@ def find_class_instances(
     class_name: str,
     superclass: str = "",
 ) -> str:
-    """Find all instances of a class in the entire scene using getclassinstances.
-
-    This searches EVERYWHERE — modifiers, materials, controllers, textures,
-    atmospherics — not just top-level objects. Use this when you need to:
-    - Audit the scene ("what materials/textures/modifiers are in use?")
-    - Find all Bitmaptextures to check file paths
-    - Count how many TurboSmooth or Bend modifiers exist scene-wide
-    - Enumerate all material types with superclass="material"
-    Prefer this over get_materials when you need to find non-assigned materials
-    or non-material classes (textures, modifiers, controllers).
+    """Find all instances of a class scene-wide (modifiers, materials, controllers, textures, etc.).
 
     Args:
-        class_name: The class to search for (e.g. "Bitmaptexture", "Bend",
-                    "VRayMtl", "Noise", "BezierFloat").
-        superclass: Optional superclass to enumerate all concrete classes under it.
-                    E.g. "material", "textureMap", "modifier", "Shadow",
-                    "Atmospheric", "renderEffect", "FloatController".
-                    When provided, class_name is ignored and ALL classes
-                    under the superclass are enumerated with counts.
-
-    Returns:
-        JSON with found instances, counts, and which scene nodes reference them.
+        class_name: Class to search for (e.g. "Bitmaptexture", "Bend", "VRayMtl").
+        superclass: Enumerate all classes under a superclass instead (e.g. "material", "modifier").
     """
     if superclass:
         safe_sc = safe_string(superclass)
@@ -117,16 +100,8 @@ def find_class_instances(
 def get_instances(name: str) -> str:
     """Get all instances (copies sharing the same base object) of a scene object.
 
-    Uses InstanceMgr to detect object-level instancing. Use this when you need
-    to know if editing one object will affect others (instanced objects share
-    geometry — changing one changes all). Also useful before renaming to find
-    all copies that should get the same name pattern.
-
     Args:
-        name: The object name to check for instances.
-
-    Returns:
-        JSON with the instance group: all objects sharing the same base object.
+        name: Object name to check for instances.
     """
     if client.native_available:
         try:
@@ -167,20 +142,11 @@ def get_dependencies(
     name: str,
     direction: str = "dependents",
 ) -> str:
-    """Trace the reference graph for an object using refs.dependents / refs.dependentnodes.
-
-    Use this to understand what an object is connected to — useful for debugging
-    why deleting/modifying one object affects another, or to map out material/
-    controller/modifier sharing across the scene.
+    """Trace the reference graph for an object.
 
     Args:
-        name: The object name to trace.
-        direction: "dependents" (what does this object depend ON — materials,
-                   controllers, modifiers, textures) or "dependentnodes"
-                   (which scene nodes reference this object's components).
-
-    Returns:
-        JSON with dependency information grouped by class.
+        name: Object name to trace.
+        direction: "dependents" (what it depends on) or "dependentnodes" (which nodes reference it).
     """
     if client.native_available:
         try:
@@ -236,19 +202,10 @@ def find_objects_by_property(
 ) -> str:
     """Find scene objects that have a specific property, optionally matching a value.
 
-    Use this for scene-wide queries like "which objects are non-renderable?",
-    "which objects have shadows disabled?", "which lights have multiplier > 1?".
-    Much faster than iterating objects manually via execute_maxscript.
-
     Args:
-        property_name: Property to check (e.g. "renderable", "castshadows",
-                       "primaryVisibility", "material").
-        property_value: Optional value to match (e.g. "false", "true").
-                        If empty, just checks if the property exists and is readable.
+        property_name: Property to check (e.g. "renderable", "castshadows").
+        property_value: Value to match (e.g. "false"). Empty = just check existence.
         class_filter: Optional class name filter (e.g. "Box", "Light").
-
-    Returns:
-        JSON list of matching objects.
     """
     if client.native_available:
         try:

--- a/src/tools/session_context.py
+++ b/src/tools/session_context.py
@@ -9,20 +9,14 @@ from ..server import mcp
 
 @mcp.tool()
 def get_session_context(
-    max_roots: int = 20,
-    max_selection: int = 20,
+    max_roots: int = 10,
+    max_selection: int = 5,
 ) -> str:
-    """Get compact live context for the current 3ds Max session.
-
-    This is the fastest "where am I?" tool for an AI client. It combines:
-    - bridge status
-    - host/plugin capabilities
-    - compact scene snapshot
-    - compact current selection snapshot
+    """Get compact live context: bridge status + capabilities + scene snapshot + selection.
 
     Args:
-        max_roots: Max top-level root names to include from the scene snapshot.
-        max_selection: Max selected objects to include from the selection snapshot.
+        max_roots: Max root names in scene snapshot (default 10).
+        max_selection: Max selected objects (default 5).
     """
     from .bridge import get_bridge_status
     from .capabilities import get_plugin_capabilities

--- a/src/tools/snapshots.py
+++ b/src/tools/snapshots.py
@@ -7,16 +7,11 @@ from ..server import mcp, client
 _previous_snapshot: dict | None = None
 
 
-@mcp.tool()
-def get_scene_snapshot(max_roots: int = 50) -> str:
-    """Compact scene overview in one call: object counts by class, materials summary,
-    modifier summary, layers, hidden/frozen counts, and top-level root names.
+# ── Private helpers ─────────────────────────────────────────────────
 
-    Use this as the first inspection call to cheaply understand a scene.
 
-    Args:
-        max_roots: Max root object names to include (default 50).
-    """
+def _get_scene_snapshot(max_roots: int = 50) -> str:
+    """Compact scene overview: class counts, materials, modifiers, layers, roots."""
     if client.native_available:
         try:
             params = {}
@@ -125,16 +120,8 @@ def get_scene_snapshot(max_roots: int = 50) -> str:
     return response.get("result", "{}")
 
 
-@mcp.tool()
-def get_selection_snapshot(max_items: int = 50) -> str:
-    """Compact info for each selected object: name, class, parent, material,
-    modifier list, position, and bounding box.
-
-    Use after get_scene_snapshot to inspect what's selected without a deep inspection call.
-
-    Args:
-        max_items: Max objects to return (default 50).
-    """
+def _get_selection_snapshot(max_items: int = 50) -> str:
+    """Compact info for each selected object."""
     if client.native_available:
         try:
             params = {}
@@ -247,16 +234,8 @@ def _diff_objects(prev: dict, curr: dict) -> dict:
     return changes
 
 
-@mcp.tool()
-def get_scene_delta(capture: bool = False) -> str:
-    """Track what changed in the scene since the last snapshot.
-
-    First call (or capture=True): captures baseline, returns object count.
-    Subsequent calls: returns added/removed/modified objects since baseline, then updates it.
-
-    Args:
-        capture: Force a fresh baseline capture without returning a delta.
-    """
+def _get_scene_delta(capture: bool = False) -> str:
+    """Track scene changes since last snapshot."""
     if client.native_available:
         try:
             params = {}
@@ -302,3 +281,30 @@ def get_scene_delta(capture: bool = False) -> str:
             "total": len(current),
         },
     })
+
+
+# ── Unified tool ────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def manage_snapshots(
+    action: str,
+    max_roots: int = 50,
+    max_items: int = 50,
+    capture: bool = False,
+) -> str:
+    """Scene snapshots for quick understanding. Actions: scene, selection, delta.
+
+    Args:
+        action: "scene" | "selection" | "delta".
+        max_roots: Max root names for scene snapshot (default 50).
+        max_items: Max objects for selection snapshot (default 50).
+        capture: Force fresh baseline for delta (no diff returned).
+    """
+    if action == "scene":
+        return _get_scene_snapshot(max_roots)
+    if action == "selection":
+        return _get_selection_snapshot(max_items)
+    if action == "delta":
+        return _get_scene_delta(capture)
+    return f"Unknown action: {action}. Use: scene, selection, delta"

--- a/src/tools/state_sets.py
+++ b/src/tools/state_sets.py
@@ -9,23 +9,11 @@ import json
 from ..server import mcp, client
 
 
-@mcp.tool()
-def get_state_sets() -> str:
-    """Get all State Sets with their camera assignments and frame ranges.
+# ── Private helpers ─────────────────────────────────────────────────
 
-    Reads the State Sets .NET API to extract:
-    - State set names
-    - Assigned camera (ActiveViewportCamera) per state set
-    - Render range (start/end frames) per state set
-    - Whether camera animation is locked to range
 
-    Use this to understand camera sequencing setups — which cameras are
-    active during which frame ranges. The data can drive USD camera
-    switch exports or Unreal Sequencer Camera Cut Track generation.
-
-    Returns:
-        JSON with all state sets, their cameras, and frame ranges.
-    """
+def _get_state_sets() -> str:
+    """Get all State Sets with camera assignments and frame ranges."""
     if client.native_available:
         response = client.send_command("{}", cmd_type="native:get_state_sets")
         return response.get("result", "")
@@ -120,21 +108,8 @@ def get_state_sets() -> str:
     return response.get("result", "")
 
 
-@mcp.tool()
-def get_camera_sequence() -> str:
-    """Get only the camera-assigned State Sets, sorted by start frame.
-
-    Filters state sets to only those with an ActiveViewportCamera assigned,
-    then sorts by render range start frame. This gives you the camera
-    switch timeline — which camera is active during which frame range.
-
-    Use this for building camera cut tracks (Unreal Sequencer) or
-    USD camera switch metadata.
-
-    Returns:
-        JSON array of camera switches sorted by start frame, with
-        camera name and frame range for each.
-    """
+def _get_camera_sequence() -> str:
+    """Get camera-assigned State Sets sorted by start frame."""
     if client.native_available:
         response = client.send_command("{}", cmd_type="native:get_camera_sequence")
         return response.get("result", "")
@@ -212,3 +187,20 @@ def get_camera_sequence() -> str:
     )"""
     response = client.send_command(maxscript)
     return response.get("result", "")
+
+
+# ── Unified tool ────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def manage_state_sets(action: str) -> str:
+    """State Sets and Camera Sequencer. Actions: list, camera_sequence.
+
+    Args:
+        action: "list" (all state sets) | "camera_sequence" (sorted camera timeline).
+    """
+    if action == "list":
+        return _get_state_sets()
+    if action == "camera_sequence":
+        return _get_camera_sequence()
+    return f"Unknown action: {action}. Use: list, camera_sequence"

--- a/src/tools/tyflow.py
+++ b/src/tools/tyflow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, Optional
 
 from src.helpers.maxscript import safe_string
 
@@ -159,8 +159,11 @@ def _assignment_lines(values: dict[str, Any], var_name: str, raw_strings: bool =
     return "\n".join(lines), names
 
 
-@mcp.tool()
-def list_tyflow_operator_types() -> str:
+# ---------------------------------------------------------------------------
+# Private helper functions (one per original @mcp.tool)
+# ---------------------------------------------------------------------------
+
+def _list_operator_types() -> str:
     """Return available and unavailable tyFlow operator names for this installation."""
     candidates = _mxs_string_array(list(KNOWN_OPERATORS))
     maxscript = f"""(
@@ -190,13 +193,12 @@ if tyFlow == undefined then (
     return json.dumps(_send_json(maxscript, {"error": "Could not parse operator probe response."}))
 
 
-@mcp.tool()
-def create_tyflow(
+def _create(
     name: str = "",
-    position: FloatList | None = None,
+    position: Optional[FloatList] = None,
     event_name: str = "Emit",
-    event_position: IntList | None = None,
-    operators: DictList | None = None,
+    event_position: Optional[IntList] = None,
+    operators: Optional[DictList] = None,
     select_created: bool = True,
 ) -> str:
     """Create tyFlow with one event and a configurable operator list."""
@@ -275,8 +277,57 @@ if tyFlow == undefined then (
     return json.dumps(payload)
 
 
-@mcp.tool()
-def get_tyflow_info(
+def _create_preset(
+    preset: str,
+    name: str = "",
+    position: Optional[FloatList] = None,
+    amount: int = 100,
+    speed: float = 120.0,
+) -> str:
+    """Create common tyFlow presets: rain, snow, fountain, burst, debris."""
+    key = preset.strip().lower()
+    if key not in {"rain", "snow", "fountain", "burst", "debris"}:
+        return json.dumps({"error": "Unsupported preset. Use rain|snow|fountain|burst|debris"})
+
+    if key == "snow":
+        shape, force_z, speed_v = "quad", -50.0, max(5.0, speed * 0.2)
+    elif key == "rain":
+        shape, force_z, speed_v = "sphere", -300.0, max(50.0, speed * 1.5)
+    elif key == "fountain":
+        shape, force_z, speed_v = "sphere", -150.0, max(80.0, speed * 1.2)
+    elif key == "burst":
+        shape, force_z, speed_v = "sphere", -30.0, max(100.0, speed * 2.0)
+    else:
+        shape, force_z, speed_v = "box", -980.0, max(30.0, speed)
+
+    flow_name = name or f"ty_{key}"
+    return _create(
+        name=flow_name,
+        position=position or [0.0, 0.0, 0.0],
+        event_name=key.capitalize(),
+        event_position=[0, 0],
+        operators=[
+            {"type": "Birth", "name": "Birth", "position": 0, "properties": {"birthMode": 0, "birthTotal": int(amount)}},
+            {"type": "Speed", "name": "Speed", "position": 1, "properties": {"magnitude": float(speed_v), "directionMode": 3}},
+            {"type": "Force", "name": "Force", "position": 2, "properties": {"gravityStrength": float(force_z)}},
+            {
+                "type": "Shape",
+                "name": "Shape",
+                "position": 3,
+                "properties": {
+                    "shape_type_tab": [1],
+                    "type_3d_ID_tab": [SHAPE_3D_IDS[shape]],
+                    "frequency_tab": [100.0],
+                    "scaleVal_tab": [100.0],
+                },
+            },
+            {"type": "Display", "name": "Display", "position": 4, "properties": {"displayMode": 2}},
+        ],
+        select_created=True,
+    )
+
+
+def _info(
     name: str,
     include_events: bool = True,
     include_operator_properties: bool = False,
@@ -540,35 +591,11 @@ if flow == undefined then (
     return json.dumps(result)
 
 
-@mcp.tool()
-def add_tyflow_event(name: str, event_name: str, event_position: IntList | None = None) -> str:
-    """Add one event to an existing tyFlow object."""
-    pos = event_position or [0, 0]
-    if len(pos) != 2:
-        raise ValueError("event_position must be [x, y]")
-
-    maxscript = f"""(
-{HELPERS}
-local flow = getNodeByName "{safe_string(name)}"
-if flow == undefined then (
-    "{{\\"error\\":\\"Object not found: {safe_string(name)}\\"}}"
-) else (
-    local evRef = flow.tyFlow.addEvent()
-    local ev = evRef.Event
-    ev.setName "{safe_string(event_name)}"
-    ev.setPosition [{int(pos[0])},{int(pos[1])}]
-    "{{\\"name\\":\\"" + (esc flow.name) + "\\",\\"event\\":\\"" + (esc ev.getName()) + "\\"}}"
-)
-)"""
-    return json.dumps(_send_json(maxscript, {"error": "Could not parse add_tyflow_event response."}))
-
-
-@mcp.tool()
-def modify_tyflow_operator(
+def _modify_operator(
     name: str,
     event_name: str,
     operator_name: str,
-    properties: dict[str, Any],
+    properties: Optional[dict[str, Any]] = None,
     raw_values: bool = False,
 ) -> str:
     """Set operator properties on an existing tyFlow event/operator pair."""
@@ -602,8 +629,111 @@ if flow == undefined then (
     return json.dumps(_send_json(maxscript, {"error": "Could not parse modify_tyflow_operator response."}))
 
 
-@mcp.tool()
-def set_tyflow_shape(
+def _add_event(name: str, event_name: str, event_position: Optional[IntList] = None) -> str:
+    """Add one event to an existing tyFlow object."""
+    pos = event_position or [0, 0]
+    if len(pos) != 2:
+        raise ValueError("event_position must be [x, y]")
+
+    maxscript = f"""(
+{HELPERS}
+local flow = getNodeByName "{safe_string(name)}"
+if flow == undefined then (
+    "{{\\"error\\":\\"Object not found: {safe_string(name)}\\"}}"
+) else (
+    local evRef = flow.tyFlow.addEvent()
+    local ev = evRef.Event
+    ev.setName "{safe_string(event_name)}"
+    ev.setPosition [{int(pos[0])},{int(pos[1])}]
+    "{{\\"name\\":\\"" + (esc flow.name) + "\\",\\"event\\":\\"" + (esc ev.getName()) + "\\"}}"
+)
+)"""
+    return json.dumps(_send_json(maxscript, {"error": "Could not parse add_tyflow_event response."}))
+
+
+def _connect_events(
+    name: str,
+    from_event: str,
+    to_event: str,
+    send_out_operator_name: str = "Send Out",
+    create_if_missing: bool = True,
+) -> str:
+    """Connect events with Send Out by applying common destination property candidates."""
+    maxscript = f"""(
+{HELPERS}
+local flow = getNodeByName "{safe_string(name)}"
+if flow == undefined then (
+    "{{\\"error\\":\\"Object not found: {safe_string(name)}\\"}}"
+) else (
+    local src = findEventSubAnim flow "{safe_string(from_event)}"
+    local dst = findEventSubAnim flow "{safe_string(to_event)}"
+    if src == undefined then (
+        "{{\\"error\\":\\"Source event not found: {safe_string(from_event)}\\"}}"
+    ) else if dst == undefined then (
+        "{{\\"error\\":\\"Destination event not found: {safe_string(to_event)}\\"}}"
+    ) else (
+        local sendOp = findOperatorSubAnim src "{safe_string(send_out_operator_name)}"
+        if sendOp == undefined and {str(bool(create_if_missing)).lower()} then (
+            local srcI = undefined
+            try (srcI = src.Event) catch ()
+            if srcI != undefined then (
+                sendOp = srcI.addOperator "Send Out" -1
+                try (sendOp.Operator.setName "{safe_string(send_out_operator_name)}") catch ()
+            )
+        )
+        if sendOp == undefined then (
+            "{{\\"error\\":\\"Send Out operator not found\\"}}"
+        ) else (
+            local applied = #()
+            local errors = #()
+            local props = #("eventName", "targetEvent", "nextEvent", "destinationEvent")
+            for pName in props do (
+                local pSym = execute ("#" + pName)
+                if isProperty sendOp pSym then (
+                    try (setProperty sendOp pSym "{safe_string(to_event)}"; append applied pName) catch (append errors ("Could not set " + pName))
+                )
+            )
+            "{{\\"name\\":\\"" + (esc flow.name) + "\\",\\"fromEvent\\":\\"{safe_string(from_event)}\\",\\"toEvent\\":\\"{safe_string(to_event)}\\",\\"operator\\":\\"{safe_string(send_out_operator_name)}\\",\\"applied\\":" + (jsonStringArray applied) + ",\\"errors\\":" + (jsonStringArray errors) + "}}"
+        )
+    )
+)
+)"""
+    return json.dumps(_send_json(maxscript, {"error": "Could not parse connect_tyflow_events response."}))
+
+
+def _remove_element(name: str, event_name: str, operator_name: str = "") -> str:
+    """Remove operator from an event, or remove event when operator_name is empty."""
+    maxscript = f"""(
+{HELPERS}
+local flow = getNodeByName "{safe_string(name)}"
+if flow == undefined then (
+    "{{\\"error\\":\\"Object not found: {safe_string(name)}\\"}}"
+) else (
+    local ev = findEventSubAnim flow "{safe_string(event_name)}"
+    if ev == undefined then (
+        "{{\\"error\\":\\"Event not found: {safe_string(event_name)}\\"}}"
+    ) else (
+        if "{safe_string(operator_name)}" != "" then (
+            local op = findOperatorSubAnim ev "{safe_string(operator_name)}"
+            if op == undefined then (
+                "{{\\"error\\":\\"Operator not found: {safe_string(operator_name)}\\"}}"
+            ) else (
+                local ok = false
+                try (op.remove(); ok = true) catch ()
+                if ok then "{{\\"removed\\":\\"operator\\",\\"event\\":\\"{safe_string(event_name)}\\",\\"operator\\":\\"{safe_string(operator_name)}\\"}}" else "{{\\"error\\":\\"Could not remove operator\\"}}"
+            )
+        ) else (
+            local ok = false
+            try (ev.remove(); ok = true) catch ()
+            if ok then "{{\\"removed\\":\\"event\\",\\"event\\":\\"{safe_string(event_name)}\\"}}" else "{{\\"error\\":\\"Could not remove event\\"}}"
+        )
+    )
+)
+)"""
+    return json.dumps(_send_json(maxscript, {"error": "Could not parse remove_tyflow_element response."}))
+
+
+def _set_shape(
     name: str,
     event_name: str = "Emit",
     operator_name: str = "Shape",
@@ -654,66 +784,50 @@ if flow == undefined then (
     return json.dumps(_send_json(maxscript, {"error": "Could not parse set_tyflow_shape response."}))
 
 
-@mcp.tool()
-def connect_tyflow_events(
+def _set_physx(
     name: str,
-    from_event: str,
-    to_event: str,
-    send_out_operator_name: str = "Send Out",
-    create_if_missing: bool = True,
+    enabled: bool = True,
+    gravity: float = -980.0,
+    substeps: int = 8,
+    pos_iterations: int = 4,
+    vel_iterations: int = 1,
 ) -> str:
-    """Connect events with Send Out by applying common destination property candidates."""
+    """Set object-level PhysX settings from tyFlow object properties."""
     maxscript = f"""(
 {HELPERS}
 local flow = getNodeByName "{safe_string(name)}"
 if flow == undefined then (
     "{{\\"error\\":\\"Object not found: {safe_string(name)}\\"}}"
 ) else (
-    local src = findEventSubAnim flow "{safe_string(from_event)}"
-    local dst = findEventSubAnim flow "{safe_string(to_event)}"
-    if src == undefined then (
-        "{{\\"error\\":\\"Source event not found: {safe_string(from_event)}\\"}}"
-    ) else if dst == undefined then (
-        "{{\\"error\\":\\"Destination event not found: {safe_string(to_event)}\\"}}"
-    ) else (
-        local sendOp = findOperatorSubAnim src "{safe_string(send_out_operator_name)}"
-        if sendOp == undefined and {str(bool(create_if_missing)).lower()} then (
-            local srcI = undefined
-            try (srcI = src.Event) catch ()
-            if srcI != undefined then (
-                sendOp = srcI.addOperator "Send Out" -1
-                try (sendOp.Operator.setName "{safe_string(send_out_operator_name)}") catch ()
-            )
-        )
-        if sendOp == undefined then (
-            "{{\\"error\\":\\"Send Out operator not found\\"}}"
-        ) else (
-            local applied = #()
-            local errors = #()
-            local props = #("eventName", "targetEvent", "nextEvent", "destinationEvent")
-            for pName in props do (
-                local pSym = execute ("#" + pName)
-                if isProperty sendOp pSym then (
-                    try (setProperty sendOp pSym "{safe_string(to_event)}"; append applied pName) catch (append errors ("Could not set " + pName))
-                )
-            )
-            "{{\\"name\\":\\"" + (esc flow.name) + "\\",\\"fromEvent\\":\\"{safe_string(from_event)}\\",\\"toEvent\\":\\"{safe_string(to_event)}\\",\\"operator\\":\\"{safe_string(send_out_operator_name)}\\",\\"applied\\":" + (jsonStringArray applied) + ",\\"errors\\":" + (jsonStringArray errors) + "}}"
+    local bo = flow.baseobject
+    local applied = #()
+    local errors = #()
+    fn setIf propName propValue = (
+        local pSym = execute ("#" + propName)
+        if isProperty bo pSym then (
+            try (setProperty bo pSym propValue; append applied propName) catch (append errors ("Could not set " + propName))
         )
     )
+    setIf "physXGravityEnabled" {str(bool(enabled)).lower()}
+    setIf "physXGravityValue" {float(gravity)}
+    setIf "physXSubsteps" {int(substeps)}
+    setIf "physXPosIterations" {int(pos_iterations)}
+    setIf "physXVelIterations" {int(vel_iterations)}
+    "{{\\"name\\":\\"" + (esc flow.name) + "\\",\\"applied\\":" + (jsonStringArray applied) + ",\\"errors\\":" + (jsonStringArray errors) + "}}"
 )
 )"""
-    return json.dumps(_send_json(maxscript, {"error": "Could not parse connect_tyflow_events response."}))
+    return json.dumps(_send_json(maxscript, {"error": "Could not parse set_tyflow_physx response."}))
 
 
-@mcp.tool()
-def add_tyflow_collision(
+def _add_collision(
     name: str,
     event_name: str,
-    collider_names: StrList,
+    collider_names: Optional[StrList] = None,
     operator_name: str = "Collision",
     create_if_missing: bool = True,
 ) -> str:
     """Add/configure Collision operator and wire collider node list."""
+    collider_names = collider_names or []
     requested = _mxs_string_array(collider_names)
     maxscript = f"""(
 {HELPERS}
@@ -761,77 +875,31 @@ if flow == undefined then (
     return json.dumps(_send_json(maxscript, {"error": "Could not parse add_tyflow_collision response."}))
 
 
-@mcp.tool()
-def set_tyflow_physx(
-    name: str,
-    enabled: bool = True,
-    gravity: float = -980.0,
-    substeps: int = 8,
-    pos_iterations: int = 4,
-    vel_iterations: int = 1,
-) -> str:
-    """Set object-level PhysX settings from tyFlow object properties."""
+def _reset_simulation(name: str = "") -> str:
+    """Reset simulation for one tyFlow object or for all tyFlow objects."""
     maxscript = f"""(
 {HELPERS}
-local flow = getNodeByName "{safe_string(name)}"
-if flow == undefined then (
-    "{{\\"error\\":\\"Object not found: {safe_string(name)}\\"}}"
+local targets = #()
+if "{safe_string(name)}" != "" then (
+    local node = getNodeByName "{safe_string(name)}"
+    if node != undefined then append targets node
 ) else (
-    local bo = flow.baseobject
-    local applied = #()
-    local errors = #()
-    fn setIf propName propValue = (
-        local pSym = execute ("#" + propName)
-        if isProperty bo pSym then (
-            try (setProperty bo pSym propValue; append applied propName) catch (append errors ("Could not set " + propName))
-        )
+    for o in objects where ((classof o.baseobject as string) == "tyFlow" or (classof o as string) == "tyFlow") do append targets o
+)
+if targets.count == 0 then (
+    "{{\\"error\\":\\"No tyFlow objects found\\"}}"
+) else (
+    local resetNames = #()
+    for n in targets do (
+        try (n.reset_simulation(); append resetNames n.name) catch ()
     )
-    setIf "physXGravityEnabled" {str(bool(enabled)).lower()}
-    setIf "physXGravityValue" {float(gravity)}
-    setIf "physXSubsteps" {int(substeps)}
-    setIf "physXPosIterations" {int(pos_iterations)}
-    setIf "physXVelIterations" {int(vel_iterations)}
-    "{{\\"name\\":\\"" + (esc flow.name) + "\\",\\"applied\\":" + (jsonStringArray applied) + ",\\"errors\\":" + (jsonStringArray errors) + "}}"
+    "{{\\"count\\":" + (resetNames.count as string) + ",\\"names\\":" + (jsonStringArray resetNames) + "}}"
 )
 )"""
-    return json.dumps(_send_json(maxscript, {"error": "Could not parse set_tyflow_physx response."}))
+    return json.dumps(_send_json(maxscript, {"error": "Could not parse reset_tyflow_simulation response."}))
 
 
-@mcp.tool()
-def remove_tyflow_element(name: str, event_name: str, operator_name: str = "") -> str:
-    """Remove operator from an event, or remove event when operator_name is empty."""
-    maxscript = f"""(
-{HELPERS}
-local flow = getNodeByName "{safe_string(name)}"
-if flow == undefined then (
-    "{{\\"error\\":\\"Object not found: {safe_string(name)}\\"}}"
-) else (
-    local ev = findEventSubAnim flow "{safe_string(event_name)}"
-    if ev == undefined then (
-        "{{\\"error\\":\\"Event not found: {safe_string(event_name)}\\"}}"
-    ) else (
-        if "{safe_string(operator_name)}" != "" then (
-            local op = findOperatorSubAnim ev "{safe_string(operator_name)}"
-            if op == undefined then (
-                "{{\\"error\\":\\"Operator not found: {safe_string(operator_name)}\\"}}"
-            ) else (
-                local ok = false
-                try (op.remove(); ok = true) catch ()
-                if ok then "{{\\"removed\\":\\"operator\\",\\"event\\":\\"{safe_string(event_name)}\\",\\"operator\\":\\"{safe_string(operator_name)}\\"}}" else "{{\\"error\\":\\"Could not remove operator\\"}}"
-            )
-        ) else (
-            local ok = false
-            try (ev.remove(); ok = true) catch ()
-            if ok then "{{\\"removed\\":\\"event\\",\\"event\\":\\"{safe_string(event_name)}\\"}}" else "{{\\"error\\":\\"Could not remove event\\"}}"
-        )
-    )
-)
-)"""
-    return json.dumps(_send_json(maxscript, {"error": "Could not parse remove_tyflow_element response."}))
-
-
-@mcp.tool()
-def get_tyflow_particle_count(name: str, frame: int | None = None, update: bool = True) -> str:
+def _particle_count(name: str, frame: Optional[int] = None, update: bool = True) -> str:
     """Return tyFlow particle count at current frame or supplied frame."""
     frame_expr = "currentTime" if frame is None else f"{int(frame)}f"
     maxscript = f"""(
@@ -852,10 +920,9 @@ if flow == undefined then (
     return json.dumps(_send_json(maxscript, {"error": "Could not parse get_tyflow_particle_count response."}))
 
 
-@mcp.tool()
-def get_tyflow_particles(
+def _particles(
     name: str,
-    frame: int | None = None,
+    frame: Optional[int] = None,
     max_particles: int = 1000,
     include_position: bool = True,
     include_velocity: bool = True,
@@ -911,77 +978,190 @@ if flow == undefined then (
     return json.dumps(_send_json(maxscript, {"error": "Could not parse get_tyflow_particles response."}))
 
 
-@mcp.tool()
-def reset_tyflow_simulation(name: str = "") -> str:
-    """Reset simulation for one tyFlow object or for all tyFlow objects."""
-    maxscript = f"""(
-{HELPERS}
-local targets = #()
-if "{safe_string(name)}" != "" then (
-    local node = getNodeByName "{safe_string(name)}"
-    if node != undefined then append targets node
-) else (
-    for o in objects where ((classof o.baseobject as string) == "tyFlow" or (classof o as string) == "tyFlow") do append targets o
-)
-if targets.count == 0 then (
-    "{{\\"error\\":\\"No tyFlow objects found\\"}}"
-) else (
-    local resetNames = #()
-    for n in targets do (
-        try (n.reset_simulation(); append resetNames n.name) catch ()
-    )
-    "{{\\"count\\":" + (resetNames.count as string) + ",\\"names\\":" + (jsonStringArray resetNames) + "}}"
-)
-)"""
-    return json.dumps(_send_json(maxscript, {"error": "Could not parse reset_tyflow_simulation response."}))
+# ---------------------------------------------------------------------------
+# Unified MCP tool
+# ---------------------------------------------------------------------------
+
+_ACTIONS: dict[str, str] = {
+    "create": "create",
+    "create_preset": "create_preset",
+    "info": "info",
+    "modify_operator": "modify_operator",
+    "add_event": "add_event",
+    "connect_events": "connect_events",
+    "remove_element": "remove_element",
+    "set_shape": "set_shape",
+    "set_physx": "set_physx",
+    "add_collision": "add_collision",
+    "reset_simulation": "reset_simulation",
+    "particle_count": "particle_count",
+    "particles": "particles",
+    "list_operator_types": "list_operator_types",
+}
 
 
 @mcp.tool()
-def create_tyflow_preset(
-    preset: str,
+def manage_tyflow(
+    action: str,
     name: str = "",
-    position: FloatList | None = None,
+    event_name: str = "",
+    operator_name: str = "",
+    position: Optional[FloatList] = None,
+    event_position: Optional[IntList] = None,
+    operators: Optional[DictList] = None,
+    select_created: bool = True,
+    properties: Optional[dict[str, Any]] = None,
+    raw_values: bool = False,
+    from_event: str = "",
+    to_event: str = "",
+    send_out_operator_name: str = "Send Out",
+    create_if_missing: bool = True,
+    collider_names: Optional[StrList] = None,
+    shape: str = "sphere",
+    scale: float = 100.0,
+    frequency: float = 100.0,
+    enabled: bool = True,
+    gravity: float = -980.0,
+    substeps: int = 8,
+    pos_iterations: int = 4,
+    vel_iterations: int = 1,
+    frame: Optional[int] = None,
+    update: bool = True,
+    max_particles: int = 1000,
+    include_position: bool = True,
+    include_velocity: bool = True,
+    include_age: bool = True,
+    include_events: bool = True,
+    include_operator_properties: bool = False,
+    max_operators_per_event: int = 200,
+    include_flow_properties: bool = False,
+    include_event_properties: bool = False,
+    max_properties_per_operator: int = 200,
+    max_properties_per_event: int = 200,
+    max_properties_on_flow: int = 200,
+    preset: str = "",
     amount: int = 100,
     speed: float = 120.0,
 ) -> str:
-    """Create common tyFlow presets: rain, snow, fountain, burst, debris."""
-    key = preset.strip().lower()
-    if key not in {"rain", "snow", "fountain", "burst", "debris"}:
-        return json.dumps({"error": "Unsupported preset. Use rain|snow|fountain|burst|debris"})
+    """Manage tyFlow particle systems. Actions: create, create_preset, info, modify_operator, add_event, connect_events, remove_element, set_shape, set_physx, add_collision, reset_simulation, particle_count, particles, list_operator_types. Key params: name, event_name, operator_name, properties, preset, shape, collider_names."""
+    if action not in _ACTIONS:
+        return json.dumps({"error": f"Unknown action '{action}'. Valid: {', '.join(sorted(_ACTIONS))}"})
 
-    if key == "snow":
-        shape, force_z, speed_v = "quad", -50.0, max(5.0, speed * 0.2)
-    elif key == "rain":
-        shape, force_z, speed_v = "sphere", -300.0, max(50.0, speed * 1.5)
-    elif key == "fountain":
-        shape, force_z, speed_v = "sphere", -150.0, max(80.0, speed * 1.2)
-    elif key == "burst":
-        shape, force_z, speed_v = "sphere", -30.0, max(100.0, speed * 2.0)
-    else:
-        shape, force_z, speed_v = "box", -980.0, max(30.0, speed)
+    if action == "list_operator_types":
+        return _list_operator_types()
 
-    flow_name = name or f"ty_{key}"
-    return create_tyflow(
-        name=flow_name,
-        position=position or [0.0, 0.0, 0.0],
-        event_name=key.capitalize(),
-        event_position=[0, 0],
-        operators=[
-            {"type": "Birth", "name": "Birth", "position": 0, "properties": {"birthMode": 0, "birthTotal": int(amount)}},
-            {"type": "Speed", "name": "Speed", "position": 1, "properties": {"magnitude": float(speed_v), "directionMode": 3}},
-            {"type": "Force", "name": "Force", "position": 2, "properties": {"gravityStrength": float(force_z)}},
-            {
-                "type": "Shape",
-                "name": "Shape",
-                "position": 3,
-                "properties": {
-                    "shape_type_tab": [1],
-                    "type_3d_ID_tab": [SHAPE_3D_IDS[shape]],
-                    "frequency_tab": [100.0],
-                    "scaleVal_tab": [100.0],
-                },
-            },
-            {"type": "Display", "name": "Display", "position": 4, "properties": {"displayMode": 2}},
-        ],
-        select_created=True,
-    )
+    if action == "create":
+        return _create(
+            name=name,
+            position=position,
+            event_name=event_name or "Emit",
+            event_position=event_position,
+            operators=operators,
+            select_created=select_created,
+        )
+
+    if action == "create_preset":
+        return _create_preset(
+            preset=preset,
+            name=name,
+            position=position,
+            amount=amount,
+            speed=speed,
+        )
+
+    if action == "info":
+        return _info(
+            name=name,
+            include_events=include_events,
+            include_operator_properties=include_operator_properties,
+            max_operators_per_event=max_operators_per_event,
+            include_flow_properties=include_flow_properties,
+            include_event_properties=include_event_properties,
+            max_properties_per_operator=max_properties_per_operator,
+            max_properties_per_event=max_properties_per_event,
+            max_properties_on_flow=max_properties_on_flow,
+        )
+
+    if action == "modify_operator":
+        return _modify_operator(
+            name=name,
+            event_name=event_name,
+            operator_name=operator_name,
+            properties=properties,
+            raw_values=raw_values,
+        )
+
+    if action == "add_event":
+        return _add_event(
+            name=name,
+            event_name=event_name,
+            event_position=event_position,
+        )
+
+    if action == "connect_events":
+        return _connect_events(
+            name=name,
+            from_event=from_event,
+            to_event=to_event,
+            send_out_operator_name=send_out_operator_name,
+            create_if_missing=create_if_missing,
+        )
+
+    if action == "remove_element":
+        return _remove_element(
+            name=name,
+            event_name=event_name,
+            operator_name=operator_name,
+        )
+
+    if action == "set_shape":
+        return _set_shape(
+            name=name,
+            event_name=event_name or "Emit",
+            operator_name=operator_name or "Shape",
+            shape=shape,
+            scale=scale,
+            frequency=frequency,
+            create_if_missing=create_if_missing,
+        )
+
+    if action == "set_physx":
+        return _set_physx(
+            name=name,
+            enabled=enabled,
+            gravity=gravity,
+            substeps=substeps,
+            pos_iterations=pos_iterations,
+            vel_iterations=vel_iterations,
+        )
+
+    if action == "add_collision":
+        return _add_collision(
+            name=name,
+            event_name=event_name,
+            collider_names=collider_names,
+            operator_name=operator_name or "Collision",
+            create_if_missing=create_if_missing,
+        )
+
+    if action == "reset_simulation":
+        return _reset_simulation(name=name)
+
+    if action == "particle_count":
+        return _particle_count(
+            name=name,
+            frame=frame,
+            update=update,
+        )
+
+    if action == "particles":
+        return _particles(
+            name=name,
+            frame=frame,
+            max_particles=max_particles,
+            include_position=include_position,
+            include_velocity=include_velocity,
+            include_age=include_age,
+        )
+
+    return json.dumps({"error": f"Unhandled action '{action}'"})

--- a/src/tools/viewport.py
+++ b/src/tools/viewport.py
@@ -86,11 +86,7 @@ def _capture_fullscreen_to_file(capture_path: str, max_width: int = 0, max_heigh
 
 @mcp.tool()
 def capture_viewport() -> Image:
-    """Capture the current 3ds Max viewport and return it as an image.
-
-    Returns the viewport screenshot as a PNG image that can be displayed
-    directly in the chat.
-    """
+    """Capture the current 3ds Max viewport as a PNG image."""
     if client.native_available:
         response = client.send_command(json.dumps({}), cmd_type="native:capture_viewport")
         data = json.loads(response.get("result", "{}"))
@@ -113,16 +109,14 @@ def capture_screen(
     max_bytes: int = DEFAULT_MAX_BYTES,
     min_width: int = DEFAULT_MIN_WIDTH,
 ) -> Image:
-    """Capture fullscreen only when explicitly enabled.
+    """Capture fullscreen (must set enabled=True). Auto-resizes to fit byte cap.
 
     Args:
-        enabled: Must be True to allow fullscreen capture.
-        max_width: Maximum output width in pixels. Use 0 to keep full width.
-        max_height: Maximum output height in pixels. Use 0 to keep full height.
-        max_bytes: Soft byte cap for output size (default 1MB). Use 0 to disable.
-        min_width: Smallest auto-resize width used when shrinking to hit max_bytes.
-
-    Returns the screenshot as a JPEG image. Aspect ratio is always preserved.
+        enabled: Must be True to allow capture.
+        max_width: Max output width (0 = full).
+        max_height: Max output height (0 = full).
+        max_bytes: Soft byte cap (default 1MB, 0 = disable).
+        min_width: Smallest auto-resize width.
     """
     if not enabled:
         raise ValueError("capture_screen is disabled by default; set enabled=True to allow fullscreen capture")
@@ -166,21 +160,10 @@ def capture_screen(
 def capture_multi_view(
     views: StrList | None = None,
 ) -> Image:
-    """Capture multiple viewport angles and stitch into a single labeled grid image.
-
-    Captures 4 orthographic views in rapid succession without user interaction,
-    stitches them into a 2x2 grid with labels, and returns as one image.
-    Gives AI complete spatial awareness from a single image — saves tokens
-    vs 4 separate capture_viewport calls.
-
-    Each view auto-zooms to scene extents before capture.
-    Original viewport state is restored after capture.
+    """Capture multiple viewports stitched into a labeled 2x2 grid image.
 
     Args:
-        views: List of view names to capture. Default: ["front", "right", "back", "top"].
-               Options: "front", "back", "left", "right", "top", "bottom", "perspective".
-
-    Returns the stitched grid image as PNG.
+        views: View names (default: ["front", "right", "back", "top"]).
     """
     payload = {}
     if views:

--- a/src/tools/wire_params.py
+++ b/src/tools/wire_params.py
@@ -11,33 +11,88 @@ from ..server import mcp, client
 from src.helpers.maxscript import safe_string, safe_name, normalize_subanim_path
 
 
+# ── Standalone tool ─────────────────────────────────────────────────
+
+
 @mcp.tool()
-def list_wireable_params(
+def wire_params(
+    source_object: str,
+    source_param: str,
+    target_object: str,
+    target_param: str,
+    expression: str,
+    two_way: bool = False,
+    reverse_expression: Optional[str] = None,
+) -> str:
+    """Wire parameters between objects. Paths MUST come from manage_wire_params(action="list") output.
+
+    Args:
+        source_object: Source object name.
+        source_param: Sub-anim path on source.
+        target_object: Target object name.
+        target_param: Sub-anim path on target.
+        expression: MAXScript expression driving the target value.
+        two_way: Create bidirectional wire (default false).
+        reverse_expression: Required when two_way=True.
+    """
+    if client.native_available:
+        payload = {
+            "source_object": source_object,
+            "source_param": source_param,
+            "target_object": target_object,
+            "target_param": target_param,
+            "expression": expression,
+            "two_way": two_way,
+            "reverse_expression": reverse_expression or "",
+        }
+        response = client.send_command(_json.dumps(payload), cmd_type="native:wire_params")
+        return response.get("result", "")
+
+    if two_way and not reverse_expression:
+        return "reverse_expression is required when two_way=True"
+
+    safe_src_obj = safe_string(source_object)
+    safe_tgt_obj = safe_string(target_object)
+    safe_src_param = safe_string(normalize_subanim_path(source_param))
+    safe_tgt_param = safe_string(normalize_subanim_path(target_param))
+    safe_expr = safe_string(expression)
+
+    src_sep = "" if safe_src_param.startswith("[") else "."
+    tgt_sep = "" if safe_tgt_param.startswith("[") else "."
+
+    lines = [
+        f'local srcObj = getNodeByName "{safe_src_obj}"',
+        f'if srcObj == undefined do return "Source object not found: {safe_src_obj}"',
+        f'local tgtObj = getNodeByName "{safe_tgt_obj}"',
+        f'if tgtObj == undefined do return "Target object not found: {safe_tgt_obj}"',
+        f'local srcSA = execute("$\'" + srcObj.name + "\'{src_sep}" + "{safe_src_param}")',
+        f'if srcSA == undefined do return "Source param not found: {safe_src_param}"',
+        f'local tgtSA = execute("$\'" + tgtObj.name + "\'{tgt_sep}" + "{safe_tgt_param}")',
+        f'if tgtSA == undefined do return "Target param not found: {safe_tgt_param}"',
+    ]
+
+    if two_way:
+        safe_rev_expr = safe_string(reverse_expression)
+        lines.append(f'paramWire.connect2way srcSA tgtSA "{safe_expr}" "{safe_rev_expr}"')
+        lines.append(f'"Wired 2-way: " + srcObj.name + ".{safe_src_param} <-> " + tgtObj.name + ".{safe_tgt_param} (fwd: {safe_expr}, rev: {safe_rev_expr})"')
+    else:
+        lines.append(f'paramWire.connect srcSA tgtSA "{safe_expr}"')
+        lines.append(f'"Wired: " + srcObj.name + ".{safe_src_param} -> " + tgtObj.name + ".{safe_tgt_param} ({safe_expr})"')
+
+    maxscript = "(\n    " + "\n    ".join(lines) + "\n)"
+    response = client.send_command(maxscript)
+    return response.get("result", str(response))
+
+
+# ── Private helpers (merged tools) ──────────────────────────────────
+
+
+def _list_wireable_params(
     name: str,
     filter: Optional[str] = None,
     depth: int = 3,
 ) -> str:
-    """Discover sub-anim parameters on an object that can be wired.
-
-    Recursively walks the sub-anim tree to find leaf parameters with
-    controllers (wireable). Use the returned paths with wire_params.
-
-    Args:
-        name: Object name (e.g. "Box001").
-        filter: Optional case-insensitive substring to filter param names
-                (e.g. "radius", "position", "bend").
-        depth: Max recursion depth (default 3, max 5). Sub-anims can be
-               deeply nested — increase if you don't find what you need.
-
-    Returns:
-        JSON array of {path, value, type, is_wireable} for each parameter.
-
-    Example paths returned:
-        "baseObject[#radius]" — sphere radius
-        "baseObject[#length]" — box length
-        "modifiers[#Bend][#angle]" — bend modifier angle
-        "position.controller[#X_Position]" — X position track
-    """
+    """Discover wireable sub-anim parameters on an object."""
     if client.native_available:
         payload = _json.dumps({
             "name": name,
@@ -107,108 +162,8 @@ def list_wireable_params(
     return response.get("result", str(response))
 
 
-@mcp.tool()
-def wire_params(
-    source_object: str,
-    source_param: str,
-    target_object: str,
-    target_param: str,
-    expression: str,
-    two_way: bool = False,
-    reverse_expression: Optional[str] = None,
-) -> str:
-    """Connect parameters between objects with a wire expression.
-
-    Creates a wire so that changes to the source parameter automatically
-    drive the target parameter via the given expression.
-
-    IMPORTANT: source_param and target_param MUST be exact paths from
-    list_wireable_params output. Do NOT invent paths like
-    "[#Object (Cylinder)][#Parameters][#height]" — they will fail.
-    Call list_wireable_params first to get valid paths.
-
-    Args:
-        source_object: Source object name (e.g. "Box001").
-        source_param: Sub-anim path on source — MUST come from list_wireable_params
-                      (e.g. "[#Object (Cylinder)][#height]").
-        target_object: Target object name (e.g. "Sphere001").
-        target_param: Sub-anim path on target (e.g. "baseObject[#radius]").
-        expression: MAXScript expression driving the target value.
-                    Use the source param's leaf name as the variable
-                    (e.g. "length / 2" if source is baseObject[#length]).
-        two_way: If true, creates bidirectional wire (default false).
-        reverse_expression: Required when two_way=True. Expression driving
-                           the source from target changes
-                           (e.g. "radius * 2").
-
-    Returns:
-        Confirmation with wired path details.
-    """
-    if client.native_available:
-        payload = {
-            "source_object": source_object,
-            "source_param": source_param,
-            "target_object": target_object,
-            "target_param": target_param,
-            "expression": expression,
-            "two_way": two_way,
-            "reverse_expression": reverse_expression or "",
-        }
-        response = client.send_command(_json.dumps(payload), cmd_type="native:wire_params")
-        return response.get("result", "")
-
-    if two_way and not reverse_expression:
-        return "reverse_expression is required when two_way=True"
-
-    safe_src_obj = safe_string(source_object)
-    safe_tgt_obj = safe_string(target_object)
-    safe_src_param = safe_string(normalize_subanim_path(source_param))
-    safe_tgt_param = safe_string(normalize_subanim_path(target_param))
-    safe_expr = safe_string(expression)
-
-    # If path starts with "[", no dot separator needed (e.g. $'Obj'[#transform])
-    src_sep = "" if safe_src_param.startswith("[") else "."
-    tgt_sep = "" if safe_tgt_param.startswith("[") else "."
-
-    lines = [
-        f'local srcObj = getNodeByName "{safe_src_obj}"',
-        f'if srcObj == undefined do return "Source object not found: {safe_src_obj}"',
-        f'local tgtObj = getNodeByName "{safe_tgt_obj}"',
-        f'if tgtObj == undefined do return "Target object not found: {safe_tgt_obj}"',
-        f'local srcSA = execute("$\'" + srcObj.name + "\'{src_sep}" + "{safe_src_param}")',
-        f'if srcSA == undefined do return "Source param not found: {safe_src_param}"',
-        f'local tgtSA = execute("$\'" + tgtObj.name + "\'{tgt_sep}" + "{safe_tgt_param}")',
-        f'if tgtSA == undefined do return "Target param not found: {safe_tgt_param}"',
-    ]
-
-    if two_way:
-        safe_rev_expr = safe_string(reverse_expression)
-        lines.append(f'paramWire.connect2way srcSA tgtSA "{safe_expr}" "{safe_rev_expr}"')
-        lines.append(f'"Wired 2-way: " + srcObj.name + ".{safe_src_param} <-> " + tgtObj.name + ".{safe_tgt_param} (fwd: {safe_expr}, rev: {safe_rev_expr})"')
-    else:
-        lines.append(f'paramWire.connect srcSA tgtSA "{safe_expr}"')
-        lines.append(f'"Wired: " + srcObj.name + ".{safe_src_param} -> " + tgtObj.name + ".{safe_tgt_param} ({safe_expr})"')
-
-    maxscript = "(\n    " + "\n    ".join(lines) + "\n)"
-    response = client.send_command(maxscript)
-    return response.get("result", str(response))
-
-
-@mcp.tool()
-def get_wired_params(name: str) -> str:
-    """Show existing wire connections on an object.
-
-    Recursively walks sub-anims looking for Wire controller classes
-    (Float_Wire, Point3_Wire, Position_Wire, etc.) and reports their
-    connections and expressions.
-
-    Args:
-        name: Object name (e.g. "Sphere001").
-
-    Returns:
-        JSON array of {param_path, controller_class, num_wires, expressions}
-        for each wired parameter.
-    """
+def _get_wired_params(name: str) -> str:
+    """Show existing wire connections on an object."""
     if client.native_available:
         payload = _json.dumps({"name": name})
         response = client.send_command(payload, cmd_type="native:get_wired_params")
@@ -273,24 +228,11 @@ def get_wired_params(name: str) -> str:
     return response.get("result", str(response))
 
 
-@mcp.tool()
-def unwire_params(
+def _unwire_params(
     object_name: str,
     param_path: str,
 ) -> str:
-    """Disconnect a wired parameter.
-
-    Removes the wire connection from the specified parameter, replacing
-    the Wire controller with a standard controller.
-
-    Args:
-        object_name: Object name (e.g. "Sphere001").
-        param_path: Sub-anim path to unwire, as shown by get_wired_params
-                    (e.g. "baseObject[#radius]").
-
-    Returns:
-        Confirmation that the wire was removed.
-    """
+    """Disconnect a wired parameter."""
     if client.native_available:
         payload = _json.dumps({"object_name": object_name, "param_path": param_path})
         response = client.send_command(payload, cmd_type="native:unwire_params")
@@ -316,3 +258,32 @@ def unwire_params(
 )"""
     response = client.send_command(maxscript)
     return response.get("result", str(response))
+
+
+# ── Unified tool ────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def manage_wire_params(
+    action: str,
+    name: str = "",
+    filter: Optional[str] = None,
+    depth: int = 3,
+    param_path: str = "",
+) -> str:
+    """Wire parameter discovery and management. Actions: list, get_wired, unwire.
+
+    Args:
+        action: "list" | "get_wired" | "unwire".
+        name: Object name.
+        filter: Substring filter for list action.
+        depth: Max recursion depth for list (default 3, max 5).
+        param_path: Sub-anim path (for unwire).
+    """
+    if action == "list":
+        return _list_wireable_params(name, filter, depth)
+    if action == "get_wired":
+        return _get_wired_params(name)
+    if action == "unwire":
+        return _unwire_params(name, param_path)
+    return f"Unknown action: {action}. Use: list, get_wired, unwire"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Shared pytest fixtures for 3dsmax-mcp tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.mock_client import MockMaxClient
+
+
+@pytest.fixture()
+def mock_client() -> MockMaxClient:
+    """Fresh MockMaxClient with native_available=True and no pre-loaded rules."""
+    return MockMaxClient(native_available=True)
+
+
+@pytest.fixture()
+def mock_client_tcp() -> MockMaxClient:
+    """MockMaxClient with native_available=False (simulates TCP-only fallback)."""
+    return MockMaxClient(native_available=False)

--- a/tests/mock_client.py
+++ b/tests/mock_client.py
@@ -1,0 +1,184 @@
+"""Reusable mock client for testing MCP tools without a live 3ds Max connection.
+
+Usage:
+    mock = MockMaxClient()
+    mock.add_response("native:ping", {"pong": True, "server": "3dsmax-mcp"})
+    mock.add_response("maxscript", {"result": "Box01"}, pattern="Box")
+
+    # In tests, patch the global client:
+    with mock.patch_client("src.tools.objects"):
+        result = create_object("Box", "TestBox")
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional
+from uuid import uuid4
+
+
+@dataclass
+class CallRecord:
+    """Immutable record of a single send_command() invocation."""
+
+    command: str
+    cmd_type: str
+    timeout: Optional[float]
+    timestamp: float
+    response: dict[str, Any]
+
+
+@dataclass
+class _ResponseRule:
+    """A rule that matches commands and returns a canned response."""
+
+    cmd_type: str
+    result: dict[str, Any]
+    pattern: Optional[str] = None
+    _compiled: Optional[re.Pattern[str]] = field(default=None, repr=False)
+
+    def matches(self, command: str, cmd_type: str) -> bool:
+        if self.cmd_type != cmd_type:
+            return False
+        if self.pattern is None:
+            return True
+        if self._compiled is None:
+            self._compiled = re.compile(self.pattern, re.IGNORECASE)
+        return bool(self._compiled.search(command))
+
+
+class MockMaxClient:
+    """Drop-in replacement for MaxClient that returns scripted responses.
+
+    Supports:
+    - Scenario-based response rules (cmd_type + optional pattern matching)
+    - Call recording for assertion
+    - native_available toggle
+    - Default fallback response
+    """
+
+    def __init__(
+        self,
+        *,
+        native_available: bool = True,
+        default_result: str = "ok",
+    ) -> None:
+        self._native_available = native_available
+        self._default_result = default_result
+        self._rules: list[_ResponseRule] = []
+        self._call_history: list[CallRecord] = []
+
+        # Satisfy MaxClient interface attributes
+        self.host = "127.0.0.1"
+        self.port = 8765
+        self.timeout = 120.0
+        self.transport = "mock"
+        self.pipe_name = r"\\.\pipe\3dsmax-mcp-mock"
+
+    # ── Configuration ────────────────────────────────────────────
+
+    @property
+    def native_available(self) -> bool:
+        return self._native_available
+
+    @native_available.setter
+    def native_available(self, value: bool) -> None:
+        self._native_available = value
+
+    def add_response(
+        self,
+        cmd_type: str,
+        result: dict[str, Any] | str,
+        *,
+        pattern: Optional[str] = None,
+    ) -> None:
+        """Register a canned response for a given cmd_type + optional command pattern.
+
+        Args:
+            cmd_type: Command type to match (e.g. "maxscript", "native:create_object").
+            result: Response payload dict, or a string shorthand for {"result": value}.
+            pattern: Optional regex to match against the command string.
+        """
+        if isinstance(result, str):
+            result = {"result": result}
+        self._rules.append(_ResponseRule(cmd_type=cmd_type, result=result, pattern=pattern))
+
+    def clear_responses(self) -> None:
+        """Remove all registered response rules."""
+        self._rules.clear()
+
+    # ── Call history ─────────────────────────────────────────────
+
+    @property
+    def call_history(self) -> list[CallRecord]:
+        return list(self._call_history)
+
+    @property
+    def call_count(self) -> int:
+        return len(self._call_history)
+
+    def last_call(self) -> CallRecord:
+        """Return the most recent call record. Raises IndexError if none."""
+        return self._call_history[-1]
+
+    def calls_for(self, cmd_type: str) -> list[CallRecord]:
+        """Filter call history by cmd_type."""
+        return [c for c in self._call_history if c.cmd_type == cmd_type]
+
+    def reset_history(self) -> None:
+        """Clear call history (keeps response rules)."""
+        self._call_history.clear()
+
+    # ── Core interface (matches MaxClient.send_command) ──────────
+
+    def send_command(
+        self,
+        command: str,
+        cmd_type: str = "maxscript",
+        timeout: Optional[float] = None,
+    ) -> dict[str, Any]:
+        """Simulate MaxClient.send_command() with canned responses."""
+        response = self._find_response(command, cmd_type)
+
+        record = CallRecord(
+            command=command,
+            cmd_type=cmd_type,
+            timeout=timeout,
+            timestamp=time.perf_counter(),
+            response=response,
+        )
+        self._call_history.append(record)
+
+        return response
+
+    # ── Patching helper ──────────────────────────────────────────
+
+    def patch_client(self, module: Any) -> Any:
+        """Return a context manager that patches `client` in an already-imported module.
+
+        Usage:
+            from src.tools import objects
+            with mock.patch_client(objects):
+                result = objects.create_object("Box")
+        """
+        from unittest.mock import patch as _patch
+        return _patch.object(module, "client", self)
+
+    # ── Internal ─────────────────────────────────────────────────
+
+    def _find_response(self, command: str, cmd_type: str) -> dict[str, Any]:
+        # Check rules in reverse order (last added wins)
+        for rule in reversed(self._rules):
+            if rule.matches(command, cmd_type):
+                return self._wrap_response(rule.result)
+        return self._wrap_response({"result": self._default_result})
+
+    def _wrap_response(self, result: dict[str, Any]) -> dict[str, Any]:
+        """Ensure response has standard fields (success, requestId, meta)."""
+        response = {"success": True, **result}
+        response.setdefault("requestId", uuid4().hex)
+        response.setdefault("meta", {"clientRoundTripMs": 0.1})
+        return response

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,104 @@
+"""Tests for connection lifecycle state machine."""
+
+import unittest
+
+from src.lifecycle import ConnectionState, LifecycleManager
+
+
+class TestLifecycleTransitions(unittest.TestCase):
+    def test_initial_state_is_disconnected(self) -> None:
+        lm = LifecycleManager()
+        self.assertEqual(lm.state, ConnectionState.DISCONNECTED)
+        self.assertFalse(lm.is_ready)
+
+    def test_happy_path_to_ready(self) -> None:
+        lm = LifecycleManager()
+        lm.transition_to(ConnectionState.CONNECTING, "pipe", "opening")
+        lm.transition_to(ConnectionState.HANDSHAKE, "pipe", "data received")
+        lm.transition_to(ConnectionState.READY, "pipe", "response ok")
+        self.assertTrue(lm.is_ready)
+        self.assertEqual(lm.transport, "pipe")
+        self.assertEqual(lm.ready_count, 1)
+
+    def test_invalid_transition_raises(self) -> None:
+        lm = LifecycleManager()
+        with self.assertRaises(ValueError):
+            lm.transition_to(ConnectionState.READY)  # Can't jump from DISCONNECTED
+
+    def test_error_from_connecting(self) -> None:
+        lm = LifecycleManager()
+        lm.transition_to(ConnectionState.CONNECTING, "pipe")
+        lm.transition_to(ConnectionState.ERROR, detail="pipe not found")
+        self.assertEqual(lm.state, ConnectionState.ERROR)
+        self.assertEqual(lm.error_count, 1)
+
+    def test_reconnect_after_error(self) -> None:
+        lm = LifecycleManager()
+        lm.transition_to(ConnectionState.CONNECTING, "pipe")
+        lm.transition_to(ConnectionState.ERROR, detail="broken")
+        lm.transition_to(ConnectionState.CONNECTING, "tcp", "fallback to tcp")
+        lm.transition_to(ConnectionState.HANDSHAKE, "tcp")
+        lm.transition_to(ConnectionState.READY, "tcp")
+        self.assertTrue(lm.is_ready)
+        self.assertEqual(lm.transport, "tcp")
+        self.assertEqual(lm.error_count, 1)
+        self.assertEqual(lm.ready_count, 1)
+
+
+class TestLifecycleHistory(unittest.TestCase):
+    def test_history_records_transitions(self) -> None:
+        lm = LifecycleManager()
+        lm.transition_to(ConnectionState.CONNECTING, "pipe")
+        lm.transition_to(ConnectionState.HANDSHAKE, "pipe")
+        self.assertEqual(len(lm.history), 2)
+        self.assertEqual(lm.history[0].to_state, ConnectionState.CONNECTING)
+        self.assertEqual(lm.history[1].to_state, ConnectionState.HANDSHAKE)
+
+    def test_history_capped_at_max(self) -> None:
+        lm = LifecycleManager()
+        lm._MAX_HISTORY = 5
+        # Cycle through states many times
+        for _ in range(10):
+            lm.transition_to(ConnectionState.CONNECTING, "pipe")
+            lm.transition_to(ConnectionState.ERROR, detail="test")
+        self.assertLessEqual(len(lm.history), 5)
+
+
+class TestLifecycleCallbacks(unittest.TestCase):
+    def test_callback_invoked_on_transition(self) -> None:
+        events: list[object] = []
+        lm = LifecycleManager()
+        lm.on_state_change(lambda e: events.append(e))
+        lm.transition_to(ConnectionState.CONNECTING, "pipe")
+        self.assertEqual(len(events), 1)
+
+    def test_broken_callback_does_not_crash(self) -> None:
+        lm = LifecycleManager()
+        lm.on_state_change(lambda e: 1 / 0)  # will raise
+        # Should not raise
+        lm.transition_to(ConnectionState.CONNECTING, "pipe")
+        self.assertEqual(lm.state, ConnectionState.CONNECTING)
+
+
+class TestLifecycleDiagnostics(unittest.TestCase):
+    def test_to_dict_snapshot(self) -> None:
+        lm = LifecycleManager()
+        lm.transition_to(ConnectionState.CONNECTING, "pipe")
+        lm.transition_to(ConnectionState.ERROR, detail="timeout")
+        d = lm.to_dict()
+        self.assertEqual(d["state"], "error")
+        self.assertEqual(d["transport"], "pipe")
+        self.assertEqual(d["errorCount"], 1)
+        self.assertEqual(d["lastError"], "timeout")
+
+    def test_reset_returns_to_disconnected(self) -> None:
+        lm = LifecycleManager()
+        lm.transition_to(ConnectionState.CONNECTING, "pipe")
+        lm.transition_to(ConnectionState.HANDSHAKE, "pipe")
+        lm.transition_to(ConnectionState.READY, "pipe")
+        lm.reset()
+        self.assertEqual(lm.state, ConnectionState.DISCONNECTED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mock_client.py
+++ b/tests/test_mock_client.py
@@ -1,0 +1,117 @@
+"""Tests for MockMaxClient itself — validates the mock infrastructure works correctly."""
+
+import unittest
+
+from tests.mock_client import MockMaxClient
+
+
+class TestMockClientResponses(unittest.TestCase):
+    def test_default_response_returns_ok(self) -> None:
+        mock = MockMaxClient()
+        response = mock.send_command("anything")
+        self.assertTrue(response["success"])
+        self.assertEqual(response["result"], "ok")
+        self.assertIn("requestId", response)
+        self.assertIn("meta", response)
+
+    def test_add_response_by_cmd_type(self) -> None:
+        mock = MockMaxClient()
+        mock.add_response("native:ping", {"pong": True, "server": "3dsmax-mcp"})
+
+        response = mock.send_command("", cmd_type="native:ping")
+        self.assertTrue(response["pong"])
+        self.assertEqual(response["server"], "3dsmax-mcp")
+
+    def test_add_response_with_pattern_matching(self) -> None:
+        mock = MockMaxClient()
+        mock.add_response("maxscript", "Box01 created", pattern=r"Box")
+        mock.add_response("maxscript", "Sphere01 created", pattern=r"Sphere")
+
+        r1 = mock.send_command("create Box name:TestBox")
+        self.assertEqual(r1["result"], "Box01 created")
+
+        r2 = mock.send_command("create Sphere radius:25")
+        self.assertEqual(r2["result"], "Sphere01 created")
+
+    def test_string_shorthand_for_result(self) -> None:
+        mock = MockMaxClient()
+        mock.add_response("maxscript", "hello world")
+        response = mock.send_command("test")
+        self.assertEqual(response["result"], "hello world")
+
+    def test_last_rule_wins_on_conflict(self) -> None:
+        mock = MockMaxClient()
+        mock.add_response("maxscript", "first")
+        mock.add_response("maxscript", "second")
+        response = mock.send_command("test")
+        self.assertEqual(response["result"], "second")
+
+    def test_unmatched_cmd_type_falls_back_to_default(self) -> None:
+        mock = MockMaxClient()
+        mock.add_response("native:ping", "pong")
+        response = mock.send_command("test", cmd_type="maxscript")
+        self.assertEqual(response["result"], "ok")
+
+
+class TestMockClientCallHistory(unittest.TestCase):
+    def test_records_all_calls(self) -> None:
+        mock = MockMaxClient()
+        mock.send_command("cmd1", cmd_type="maxscript")
+        mock.send_command("cmd2", cmd_type="native:ping")
+        self.assertEqual(mock.call_count, 2)
+
+    def test_last_call_returns_most_recent(self) -> None:
+        mock = MockMaxClient()
+        mock.send_command("first")
+        mock.send_command("second")
+        self.assertEqual(mock.last_call().command, "second")
+
+    def test_calls_for_filters_by_cmd_type(self) -> None:
+        mock = MockMaxClient()
+        mock.send_command("a", cmd_type="maxscript")
+        mock.send_command("b", cmd_type="native:ping")
+        mock.send_command("c", cmd_type="maxscript")
+        self.assertEqual(len(mock.calls_for("maxscript")), 2)
+        self.assertEqual(len(mock.calls_for("native:ping")), 1)
+
+    def test_reset_history_clears_records(self) -> None:
+        mock = MockMaxClient()
+        mock.send_command("test")
+        mock.reset_history()
+        self.assertEqual(mock.call_count, 0)
+
+
+class TestMockClientNativeToggle(unittest.TestCase):
+    def test_native_available_defaults_to_true(self) -> None:
+        mock = MockMaxClient()
+        self.assertTrue(mock.native_available)
+
+    def test_native_available_can_be_disabled(self) -> None:
+        mock = MockMaxClient(native_available=False)
+        self.assertFalse(mock.native_available)
+
+    def test_native_available_can_be_toggled(self) -> None:
+        mock = MockMaxClient()
+        mock.native_available = False
+        self.assertFalse(mock.native_available)
+
+
+class TestMockClientPatchHelper(unittest.TestCase):
+    def test_patch_client_replaces_module_client(self) -> None:
+        from unittest.mock import patch as _patch
+        from src.tools import objects as objects_mod
+
+        mock = MockMaxClient()
+        mock.add_response("native:delete_objects", "Deleted: Box01")
+
+        with _patch.object(objects_mod, "client", mock):
+            result = objects_mod.delete_objects(["Box01"])
+            # Result includes safety warning for dangerous tools
+            self.assertIn("Deleted: Box01", result)
+
+        self.assertEqual(mock.call_count, 1)
+        self.assertEqual(mock.last_call().cmd_type, "native:delete_objects")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -4,15 +4,15 @@ from unittest.mock import patch
 
 from src.tools.plugins import (
     _build_manifest,
+    _discover_surface,
+    _get_manifest,
+    _inspect_class,
+    _inspect_instance,
+    _list_classes,
     _plugin_gotchas_markdown,
     _plugin_guide_markdown,
     _plugin_recipe_markdown,
     _parse_showclass_lines,
-    discover_plugin_surface,
-    get_plugin_manifest,
-    inspect_plugin_class,
-    inspect_plugin_instance,
-    list_plugin_classes,
     plugin_gotchas_resource,
     plugin_guide_resource,
     plugin_index_resource,
@@ -46,7 +46,7 @@ class PluginToolTests(unittest.TestCase):
 
     def test_list_plugin_classes_filters_by_plugin(self) -> None:
         with patch("src.tools.plugins._fetch_runtime_classes", return_value=RUNTIME_CLASSES):
-            result = json.loads(list_plugin_classes(plugin_name="tyflow", limit=1))
+            result = json.loads(_list_classes(plugin_name="tyflow", limit=1))
 
         self.assertEqual(result["count"], 1)
         self.assertEqual(result["classes"][0]["name"], "tyFlow")
@@ -58,7 +58,7 @@ class PluginToolTests(unittest.TestCase):
             patch("src.tools.plugins._get_scene_instance_counts", return_value={"tyFlow": 2, "tyMesher": 0}),
             patch("src.tools.plugins.get_plugin_capabilities", return_value='{"maxVersion":2026,"renderer":"Arnold","plugins":{"tyFlow":true}}'),
         ):
-            result = json.loads(discover_plugin_surface(plugin_name="tyflow"))
+            result = json.loads(_discover_surface(plugin_name="tyflow"))
 
         self.assertEqual(result["plugin"], "tyFlow")
         self.assertEqual(result["installed"], True)
@@ -74,7 +74,7 @@ class PluginToolTests(unittest.TestCase):
             patch("src.tools.plugins._get_scene_instance_counts", return_value={"tyFlow": 1, "tyMesher": 0}),
             patch("src.tools.plugins.get_plugin_capabilities", return_value='{"plugins":{"tyFlow":false}}'),
         ):
-            result = json.loads(discover_plugin_surface(plugin_name="tyflow"))
+            result = json.loads(_discover_surface(plugin_name="tyflow"))
 
         self.assertEqual(result["installed"], True)
         self.assertEqual(result["installation"]["status"], "runtime_only")
@@ -89,7 +89,7 @@ class PluginToolTests(unittest.TestCase):
                 "  .allowCustomWirecolor : boolean",
             ]),
         ):
-            result = json.loads(inspect_plugin_class("tyFlow"))
+            result = json.loads(_inspect_class("tyFlow"))
 
         self.assertEqual(result["class"], "tyFlow")
         self.assertEqual(result["category"], "geometry")
@@ -106,7 +106,7 @@ class PluginToolTests(unittest.TestCase):
                 "  .simResetMode : integer",
             ]),
         ):
-            result = json.loads(inspect_plugin_class("tyFlow", include_methods=False))
+            result = json.loads(_inspect_class("tyFlow", include_methods=False))
 
         self.assertEqual(result["methods"], [])
         self.assertEqual(result["methodReflectionSupported"], False)
@@ -122,7 +122,7 @@ class PluginToolTests(unittest.TestCase):
                 "  .spline : node",
             ]),
         ):
-            result = json.loads(inspect_plugin_class("RailClone_Pro"))
+            result = json.loads(_inspect_class("RailClone_Pro"))
 
         self.assertEqual(result["class"], "RailClone_Pro")
         self.assertEqual(result["properties"][0]["name"], "spline")
@@ -175,7 +175,7 @@ class PluginToolTests(unittest.TestCase):
 
     def test_get_plugin_manifest_returns_json(self) -> None:
         with patch("src.tools.plugins._build_manifest", return_value={"plugin": "tyFlow", "installed": True}):
-            result = json.loads(get_plugin_manifest("tyflow"))
+            result = json.loads(_get_manifest("tyflow"))
 
         self.assertEqual(result["plugin"], "tyFlow")
         self.assertEqual(result["installed"], True)
@@ -214,8 +214,8 @@ class PluginToolTests(unittest.TestCase):
 
     def test_plugin_resources_delegate_to_tooling(self) -> None:
         with (
-            patch("src.tools.plugins.discover_plugin_surface", return_value='{"plugins":[{"plugin":"tyFlow"}]}'),
-            patch("src.tools.plugins.get_plugin_manifest", return_value='{"plugin":"tyFlow","installed":true}'),
+            patch("src.tools.plugins._discover_surface", return_value='{"plugins":[{"plugin":"tyFlow"}]}'),
+            patch("src.tools.plugins._get_manifest", return_value='{"plugin":"tyFlow","installed":true}'),
             patch("src.tools.plugins._plugin_guide_markdown", return_value="# tyFlow"),
             patch("src.tools.plugins._plugin_recipe_markdown", return_value="# tyFlow Recipes"),
             patch("src.tools.plugins._plugin_gotchas_markdown", return_value="# tyFlow Gotchas"),
@@ -238,7 +238,7 @@ class PluginToolTests(unittest.TestCase):
             patch("src.tools.inspect.inspect_properties", return_value='{"class":"tyFlow","propertyCount":2,"properties":[{"name":"simResetMode","value":"0","declaredType":"integer","runtimeType":"Integer"},{"name":"allowCustomWirecolor","value":"true","declaredType":"boolean","runtimeType":"BooleanClass"}]}'),
             patch("src.tools.plugins._build_manifest", return_value={"plugin": "tyFlow", "installed": True}),
         ):
-            result = json.loads(inspect_plugin_instance("Flow001"))
+            result = json.loads(_inspect_instance("Flow001"))
 
         self.assertEqual(result["plugin"], "tyFlow")
         self.assertEqual(result["manifest"]["plugin"], "tyFlow")
@@ -253,7 +253,7 @@ class PluginToolTests(unittest.TestCase):
             patch("src.tools.inspect.inspect_properties", return_value='{"class":"tyFlow","propertyCount":1,"properties":[{"name":"simResetMode","value":"0","declaredType":"integer","runtimeType":"Integer"}]}'),
             patch("src.tools.plugins._build_manifest", side_effect=lambda plugin: {"plugin": plugin}),
         ):
-            result = json.loads(inspect_plugin_instance("Hybrid001"))
+            result = json.loads(_inspect_instance("Hybrid001"))
 
         self.assertEqual(result["primaryPlugin"], "tyFlow")
         self.assertIn("Detected from the object's runtime class", result["primaryPluginReason"])

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,77 @@
+"""Tests for the safety gate module."""
+
+import unittest
+
+from src.safety import RiskLevel, classify_risk, format_safety_warning, wrap_with_safety
+
+
+class TestClassifyRisk(unittest.TestCase):
+    def test_delete_objects_is_dangerous(self) -> None:
+        risk = classify_risk("delete_objects")
+        self.assertEqual(risk.level, RiskLevel.DANGEROUS)
+        self.assertIn("remove", risk.reason.lower())
+
+    def test_execute_maxscript_is_dangerous(self) -> None:
+        risk = classify_risk("execute_maxscript")
+        self.assertEqual(risk.level, RiskLevel.DANGEROUS)
+
+    def test_manage_scene_reset_is_dangerous(self) -> None:
+        risk = classify_risk("manage_scene", action="reset")
+        self.assertEqual(risk.level, RiskLevel.DANGEROUS)
+        self.assertIn("reset", risk.reason.lower())
+
+    def test_manage_scene_hold_is_safe(self) -> None:
+        risk = classify_risk("manage_scene", action="hold")
+        self.assertEqual(risk.level, RiskLevel.SAFE)
+
+    def test_manage_scene_info_is_safe(self) -> None:
+        risk = classify_risk("manage_scene", action="info")
+        self.assertEqual(risk.level, RiskLevel.SAFE)
+
+    def test_manage_scene_save_is_caution(self) -> None:
+        risk = classify_risk("manage_scene", action="save")
+        self.assertEqual(risk.level, RiskLevel.CAUTION)
+
+    def test_unknown_tool_is_safe(self) -> None:
+        risk = classify_risk("get_scene_info")
+        self.assertEqual(risk.level, RiskLevel.SAFE)
+
+
+class TestFormatSafetyWarning(unittest.TestCase):
+    def test_safe_returns_empty(self) -> None:
+        risk = classify_risk("get_scene_info")
+        self.assertEqual(format_safety_warning(risk), "")
+
+    def test_dangerous_includes_reason_and_suggestion(self) -> None:
+        risk = classify_risk("delete_objects")
+        warning = format_safety_warning(risk)
+        self.assertIn("DANGEROUS", warning)
+        self.assertIn("hold", warning.lower())
+
+
+class TestWrapWithSafety(unittest.TestCase):
+    def test_safe_tool_returns_result_unchanged(self) -> None:
+        result = wrap_with_safety("get_scene_info", "some data")
+        self.assertEqual(result, "some data")
+
+    def test_dangerous_tool_prepends_warning(self) -> None:
+        result = wrap_with_safety("delete_objects", "Deleted: Box01")
+        self.assertTrue(result.startswith("WARNING:"))
+        self.assertIn("Deleted: Box01", result)
+
+    def test_caution_tool_returns_result_unchanged(self) -> None:
+        result = wrap_with_safety("manage_scene", "Saved: test.max", action="save")
+        self.assertEqual(result, "Saved: test.max")
+
+    def test_conditional_dangerous_prepends_warning(self) -> None:
+        result = wrap_with_safety("manage_scene", "Scene reset", action="reset")
+        self.assertTrue(result.startswith("WARNING:"))
+        self.assertIn("Scene reset", result)
+
+    def test_conditional_safe_returns_unchanged(self) -> None:
+        result = wrap_with_safety("manage_scene", "Hold ok", action="hold")
+        self.assertEqual(result, "Hold ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Merge similar MCP tools into `manage_*` pattern (111→58 tools)
- Trim all tool docstrings from 67K to 21K chars
- Remove SKILL.md full embed from server prompt
- Add pymxs integration, version breaking changes, debugging docs to skills
- Add /push and /pull sync commands for GitHub/GCP/mobile workflow
- Lower default response limits for heavy tools

Session start tokens: ~24,758 → ~6,141 (75% reduction)

## Test plan
- [ ] MCP server starts without errors
- [ ] All merged tools respond correctly via action parameter
- [ ] Standalone tools unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)