### PR TITLE
feat: prioritize ADSK_3DSMAX_x64_<year> env var for installation sour…

### DIFF
--- a/install.py
+++ b/install.py
@@ -27,23 +27,6 @@ GUP_SRCS = {
 }
 
 
-def max_year_for(max_dir: Path) -> int | None:
-    try:
-        return int(max_dir.name.split()[-1])
-    except (ValueError, IndexError):
-        return None
-
-
-def gup_src_for(max_dir: Path) -> Path | None:
-    year = max_year_for(max_dir)
-    if year is None:
-        return None
-    src = GUP_SRCS.get(year)
-    if src and src.exists():
-        return src
-    return None
-
-
 MS_SERVER = ROOT / "maxscript" / "mcp_server.ms"
 MS_AUTOSTART = ROOT / "maxscript" / "startup" / "mcp_autostart.ms"
 CONFIG_SRC = ROOT / "mcp_config.ini"
@@ -63,18 +46,42 @@ SKILL_SRC = ROOT / "skills" / "3dsmax-mcp-dev" / "SKILL.md"
 SKILL_DIR = CONFIG_DIR / "skill"
 SKILL_DST = SKILL_DIR / "SKILL.md"
 
-# Common Max install locations (newest first)
-MAX_DIRS = [
-    Path(r"C:\Program Files\Autodesk\3ds Max 2027"),
-    Path(r"C:\Program Files\Autodesk\3ds Max 2026"),
-    Path(r"C:\Program Files\Autodesk\3ds Max 2025"),
-    Path(r"C:\Program Files\Autodesk\3ds Max 2024"),
-    Path(r"C:\Program Files\Autodesk\3ds Max 2023"),
-]
+# Extract list of supported years from GUP_SRCS
+MAX_YEARS = sorted(GUP_SRCS.keys(), reverse=True)
+
+# Find the 3ds Max installation directory for a given year
+# First check the environment variable, then the default location (ADSK_3DSMAX_x64_{year})
+def max_dir_for_year(year: int) -> Path:
+    # Set by 3ds Max installer
+    env = os.environ.get(f"ADSK_3DSMAX_x64_{year}", "").strip()
+    if env:
+        return Path(env)
+    # Default location
+    return Path(rf"C:\Program Files\Autodesk\3ds Max {year}")
+
+
+def max_year_for(max_dir: Path) -> int | None:
+    for year in MAX_YEARS:
+        if max_dir_for_year(year) == max_dir:
+            return year
+    try:
+        return int(max_dir.name.split()[-1])
+    except (ValueError, IndexError):
+        return None
+
+
+def gup_src_for(max_dir: Path) -> Path | None:
+    year = max_year_for(max_dir)
+    if year is None:
+        return None
+    src = GUP_SRCS.get(year)
+    if src and src.exists():
+        return src
+    return None
 
 
 def find_max_installations() -> list[Path]:
-    return [d for d in MAX_DIRS if (d / "3dsmax.exe").exists()]
+    return [d for d in (max_dir_for_year(y) for y in MAX_YEARS) if (d / "3dsmax.exe").exists()]
 
 
 def find_max() -> Path | None:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -9,6 +9,31 @@ def test_max_year_for_reads_standard_install_folder_names() -> None:
     assert install.max_year_for(Path(r"C:\weird\Max")) is None
 
 
+def test_max_year_for_uses_installer_env_var_for_custom_paths(monkeypatch, tmp_path: Path) -> None:
+    custom = tmp_path / "custom-max"
+    custom.mkdir()
+    monkeypatch.setenv("ADSK_3DSMAX_x64_2025", str(custom))
+    assert install.max_year_for(custom) == 2025
+
+
+def test_find_max_installations_uses_env_var_path(monkeypatch, tmp_path: Path) -> None:
+    custom = tmp_path / "custom-max-2026"
+    custom.mkdir()
+    (custom / "3dsmax.exe").write_text("", encoding="utf-8")
+    monkeypatch.setenv("ADSK_3DSMAX_x64_2026", str(custom))
+    assert install.find_max_installations() == [custom]
+
+
+def test_max_dir_for_year_prefers_env_over_default(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("ADSK_3DSMAX_x64_2025", str(tmp_path))
+    assert install.max_dir_for_year(2025) == tmp_path
+
+
+def test_max_dir_for_year_falls_back_to_default(monkeypatch) -> None:
+    monkeypatch.delenv("ADSK_3DSMAX_x64_2025", raising=False)
+    assert install.max_dir_for_year(2025) == Path(r"C:\Program Files\Autodesk\3ds Max 2025")
+
+
 def test_native_bridge_sources_are_exact_versioned_binaries() -> None:
     for year in (2023, 2024, 2025, 2026, 2027):
         assert install.GUP_SRCS[year].name == f"mcp_bridge_{year}.gup"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "3dsmax-mcp"
-version = "1.0.6"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
@@ -222,7 +222,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
…ce dir

3ds Max installer sets env variable `ADSK_3DSMAX_x64_<year>` for every Max version installed. Going by the default Programs path breaks for non-default installation directories.

Ref: https://help.autodesk.com/view/3DSMAX/2026/ENU/?guid=GUID-D7D373FD-CA78-4986-AB3D-B1E25F2A37CC
