### PR TITLE
feat: use plugin AppBundle for install/uninstall process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,6 @@ native/build-*/
 native/build2027/
 native/generated/
 !native/bin/
-native/bin/*.gup
-native/scripts/
 bundle/PackageContents.xml
 
 # Dev convenience scripts are personal — install.py is the user-facing installer,

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ native/build-*/
 native/build2027/
 native/generated/
 !native/bin/
+native/bin/*.gup
+native/scripts/
+bundle/PackageContents.xml
 
 # Dev convenience scripts are personal — install.py is the user-facing installer,
 # build.bat/clean.bat stay for devs who want a bare build. Everything else is local.

--- a/bundle/PackageContents.xml.in
+++ b/bundle/PackageContents.xml.in
@@ -8,8 +8,8 @@
   Description="MCP bridge for AI agents to control 3ds Max"
   AppVersion="__APP_VERSION__"
   FriendlyVersion="__APP_VERSION__"
-  ProductCode="{a7c3e1f4-2b8d-4e6a-9f0c-1d5e8b3a7c2f}"
-  UpgradeCode="{f4e2c8b1-6d3a-4f7e-8b0c-9e1d5a3f7b2e}">
+  ProductCode="{e2c7f59f-b2a3-489f-bf01-e2c6281126d0}"
+  UpgradeCode="{07bb0422-8d22-4fa8-bfb6-4cadc7b5cf4c}">
   <CompanyDetails Name="Metaverse Makers" />
   <Components Description="plugins parts">
     <RuntimeRequirements OS="Win64" Platform="3ds Max" SeriesMin="2023" SeriesMax="2023" />

--- a/bundle/PackageContents.xml.in
+++ b/bundle/PackageContents.xml.in
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Template for PackageContents.xml — AppVersion is injected at install/stage time -->
+<ApplicationPackage
+  SchemaVersion="1.0"
+  AutodeskProduct="3ds Max"
+  ProductType="Application"
+  Name="3dsmax-mcp"
+  Description="MCP bridge for AI agents to control 3ds Max"
+  AppVersion="__APP_VERSION__"
+  FriendlyVersion="__APP_VERSION__"
+  ProductCode="{a7c3e1f4-2b8d-4e6a-9f0c-1d5e8b3a7c2f}"
+  UpgradeCode="{f4e2c8b1-6d3a-4f7e-8b0c-9e1d5a3f7b2e}">
+  <CompanyDetails Name="Metaverse Makers" />
+  <Components Description="plugins parts">
+    <RuntimeRequirements OS="Win64" Platform="3ds Max" SeriesMin="2023" SeriesMax="2023" />
+    <ComponentEntry ModuleName="./Contents/bin/mcp_bridge_2023.gup" />
+  </Components>
+  <Components Description="plugins parts">
+    <RuntimeRequirements OS="Win64" Platform="3ds Max" SeriesMin="2024" SeriesMax="2024" />
+    <ComponentEntry ModuleName="./Contents/bin/mcp_bridge_2024.gup" />
+  </Components>
+  <Components Description="plugins parts">
+    <RuntimeRequirements OS="Win64" Platform="3ds Max" SeriesMin="2025" SeriesMax="2025" />
+    <ComponentEntry ModuleName="./Contents/bin/mcp_bridge_2025.gup" />
+  </Components>
+  <Components Description="plugins parts">
+    <RuntimeRequirements OS="Win64" Platform="3ds Max" SeriesMin="2026" SeriesMax="2026" />
+    <ComponentEntry ModuleName="./Contents/bin/mcp_bridge_2026.gup" />
+  </Components>
+  <Components Description="plugins parts">
+    <RuntimeRequirements OS="Win64" Platform="3ds Max" SeriesMin="2027" SeriesMax="2027" />
+    <ComponentEntry ModuleName="./Contents/bin/mcp_bridge_2027.gup" />
+  </Components>
+  <Components Description="post-start-up scripts parts">
+    <RuntimeRequirements OS="Win64" Platform="3ds Max" SeriesMin="2023" SeriesMax="2027" />
+    <ComponentEntry ModuleName="./Contents/scripts/mcp_server.ms" />
+  </Components>
+</ApplicationPackage>

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -33,7 +33,35 @@ Skip skill deployment:
 uv run python install.py --skip-skill
 ```
 
-After install, restart 3ds Max. The installer deploys the native GUP for your Max version, copies startup MAXScript, writes config under `%LOCALAPPDATA%\3dsmax-mcp\`, builds the agent skill, and registers MCP entries where it can (Claude Desktop, Cursor, Gemini, CLI agents).
+After install, restart 3ds Max. The installer:
+
+1. Removes any **legacy** files copied into the Max install directory (`plugins\mcp_bridge.gup`, `scripts\mcp\`, `scripts\startup\mcp_autostart.ms`) from older installs.
+2. Deploys an **ApplicationPlugins bundle** to `%ProgramData%\Autodesk\ApplicationPlugins\3dsmax-mcp\` (native GUPs in `Contents\bin\`, MAXScript in `Contents\scripts\`).
+3. Writes user config under `%LOCALAPPDATA%\3dsmax-mcp\`, builds the agent skill, and registers MCP entries where it can (Claude Desktop, Cursor, Gemini, CLI agents).
+
+### Application package layout
+
+```
+%ProgramData%\Autodesk\ApplicationPlugins\3dsmax-mcp\
+  PackageContents.xml
+  Contents\
+    bin\mcp_bridge_2023.gup … mcp_bridge_2027.gup
+    scripts\mcp_server.ms
+```
+
+Manifest template: [`bundle/PackageContents.xml.in`](../bundle/PackageContents.xml.in). Max loads the GUP matching its version (`plugins parts`) and the shared TCP fallback script (`post-start-up scripts parts`).
+
+### Dev testing without install
+
+Build native binaries, stage the bundle, and point Max at it:
+
+```powershell
+native\build.bat all
+uv run python scripts/stage_bundle.py --dest bundle
+set ADSK_APPLICATION_PLUGINS=C:\path\to\3dsmax-mcp\bundle
+```
+
+Then launch 3ds Max. For a full install, run `uv run python install.py` (also migrates away legacy install-dir copies automatically).
 
 ## MCP client registration
 
@@ -186,7 +214,7 @@ External helper tools (for automation outside Max): `send_to_chat`, `chat_status
 
 Only needed when modifying C++ handlers.
 
-Install matching 3ds Max SDKs. Builds land in `native/bin/`; `install.py` deploys the binary for the detected Max version.
+Install matching 3ds Max SDKs. Builds land in `native/bin/` and are staged into `bundle/Contents/bin/`. Run `uv run python install.py` to deploy the application package to `%ProgramData%\Autodesk\ApplicationPlugins\3dsmax-mcp\`.
 
 ```powershell
 cd native

--- a/install.py
+++ b/install.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """One-step installer for 3dsmax-mcp.
 
-Detects 3ds Max, deploys the native bridge, installs MAXScript listener,
-builds skills, and registers with AI agents.
+Removes legacy Max install-dir copies, deploys the ApplicationPlugins bundle,
+installs user config, builds skills, and registers with AI agents.
 
 Run:  uv run python install.py
 Skip skill install: uv run python install.py --skip-skill
@@ -16,6 +16,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent
@@ -27,9 +28,13 @@ GUP_SRCS = {
     2027: ROOT / "native" / "bin" / "mcp_bridge_2027.gup",
 }
 
+BUNDLE_SRC = ROOT / "bundle"
+BUNDLE_PACKAGE_NAME = "3dsmax-mcp"
+APPLICATION_PACKAGE_DST = (
+    Path(os.environ.get("ProgramData", "")) / "Autodesk" / "ApplicationPlugins" / BUNDLE_PACKAGE_NAME
+)
 
 MS_SERVER = ROOT / "maxscript" / "mcp_server.ms"
-MS_AUTOSTART = ROOT / "maxscript" / "startup" / "mcp_autostart.ms"
 CONFIG_SRC = ROOT / "mcp_config.ini"
 CONFIG_DIR = Path(os.environ.get("LOCALAPPDATA", "")) / "3dsmax-mcp"
 CONFIG_DST = CONFIG_DIR / "mcp_config.ini"
@@ -82,15 +87,14 @@ def installer_banner() -> str:
 
 # Extract list of supported years from GUP_SRCS
 MAX_YEARS = sorted(GUP_SRCS.keys(), reverse=True)
+PACKAGE_CONTENTS_TEMPLATE = BUNDLE_SRC / "PackageContents.xml.in"
+APP_VERSION_PLACEHOLDER = "__APP_VERSION__"
 
-# Find the 3ds Max installation directory for a given year
-# First check the environment variable, then the default location (ADSK_3DSMAX_x64_{year})
+
 def max_dir_for_year(year: int) -> Path:
-    # Set by 3ds Max installer
     env = os.environ.get(f"ADSK_3DSMAX_x64_{year}", "").strip()
     if env:
         return Path(env)
-    # Default location
     return Path(rf"C:\Program Files\Autodesk\3ds Max {year}")
 
 
@@ -123,134 +127,179 @@ def find_max() -> Path | None:
     return found[0] if found else None
 
 
-def select_max(found: list[Path]) -> Path | None:
-    if not found:
-        return None
-    if len(found) == 1:
-        return found[0]
-    print("\nMultiple 3ds Max installations found:")
-    for i, d in enumerate(found, 1):
-        print(f"  {i}) {d}")
-    choice = input(f"  Select version [1]: ").strip()
-    try:
-        idx = int(choice) - 1
-        if 0 <= idx < len(found):
-            return found[idx]
-    except ValueError:
-        pass
-    return found[0]
+def legacy_install_paths(max_dir: Path) -> list[Path]:
+    return [
+        max_dir / "plugins" / "mcp_bridge.gup",
+        max_dir / "scripts" / "mcp" / "mcp_server.ms",
+        max_dir / "scripts" / "startup" / "mcp_autostart.ms",
+    ]
 
 
-def copy_elevated(src: Path, dst: Path) -> bool:
-    """Copy a file, elevating to admin if needed."""
+def legacy_mcp_script_dir(max_dir: Path) -> Path:
+    return max_dir / "scripts" / "mcp"
+
+
+def delete_elevated(path: Path) -> bool:
+    if not path.exists():
+        return True
     try:
-        shutil.copy2(src, dst)
+        path.unlink()
         return True
     except PermissionError:
-        print(f"  Need admin rights for {dst.parent}")
-        cmd = f'copy /Y "{src}" "{dst}"'
-        result = subprocess.run(
+        print(f"  Need admin rights for {path}")
+        cmd = f'del /F "{path}"'
+        subprocess.run(
             ["powershell", "-Command",
              f'Start-Process -FilePath cmd.exe -ArgumentList \'/c {cmd}\' -Verb RunAs -Wait'],
             capture_output=True, timeout=30,
         )
-        return dst.exists()
+        return not path.exists()
+
+
+def _legacy_max_dirs(extra_dirs: list[Path] | None = None) -> list[Path]:
+    seen: set[str] = set()
+    dirs: list[Path] = []
+    for candidate in [*find_max_installations(), *(extra_dirs or [])]:
+        key = str(candidate)
+        if key in seen:
+            continue
+        seen.add(key)
+        dirs.append(candidate)
+    return dirs
+
+
+def remove_legacy_installations(extra_dirs: list[Path] | None = None) -> bool:
+    """Remove old-format installs from every known Max dir. Returns False if any remain."""
+    print("\nPre-flight: removing legacy installation files")
+    max_dirs = _legacy_max_dirs(extra_dirs)
+    if not max_dirs:
+        print("  No 3ds Max installations scanned (legacy paths only checked when Max is found)")
+
+    for max_dir in max_dirs:
+        print(f"  Scanning: {max_dir}")
+        for path in legacy_install_paths(max_dir):
+            if not path.exists():
+                continue
+            if delete_elevated(path):
+                print(f"    Removed: {path}")
+            else:
+                print(f"    FAILED: {path}")
+
+        mcp_dir = legacy_mcp_script_dir(max_dir)
+        if mcp_dir.exists() and mcp_dir.is_dir() and not any(mcp_dir.iterdir()):
+            try:
+                mcp_dir.rmdir()
+                print(f"    Removed empty: {mcp_dir}")
+            except OSError:
+                pass
+
+    remaining = [
+        path
+        for max_dir in max_dirs
+        for path in legacy_install_paths(max_dir)
+        if path.exists()
+    ]
+    if remaining:
+        print("\n  ERROR: legacy files still present:")
+        for path in remaining:
+            print(f"    {path}")
+        print("  Close 3ds Max and re-run the installer.")
+        return False
+
+    print("  OK: no legacy installation files remain")
+    return True
+
+
+def package_contents_xml(app_version: str) -> str:
+    if PACKAGE_CONTENTS_TEMPLATE.exists():
+        text = PACKAGE_CONTENTS_TEMPLATE.read_text(encoding="utf-8")
+        return text.replace(APP_VERSION_PLACEHOLDER, app_version)
+    raise FileNotFoundError(f"Missing bundle template: {PACKAGE_CONTENTS_TEMPLATE}")
+
+
+def stage_bundle(dest: Path) -> tuple[list[int], list[int]]:
+    """Stage ApplicationPlugins bundle. Returns (included years, missing years)."""
+    bin_dir = dest / "Contents" / "bin"
+    scripts_dir = dest / "Contents" / "scripts"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+
+    included: list[int] = []
+    missing: list[int] = []
+    for year in sorted(GUP_SRCS.keys()):
+        src = GUP_SRCS[year]
+        if src.exists():
+            shutil.copy2(src, bin_dir / src.name)
+            included.append(year)
+        else:
+            missing.append(year)
+
+    if MS_SERVER.exists():
+        shutil.copy2(MS_SERVER, scripts_dir / "mcp_server.ms")
+
+    (dest / "PackageContents.xml").write_text(
+        package_contents_xml(pkg_version()), encoding="utf-8"
+    )
+    return included, missing
+
+
+def deploy_application_package() -> bool:
+    print(f"\n[2/4] Application package -> {APPLICATION_PACKAGE_DST}")
+    if not MS_SERVER.exists():
+        print(f"  FAILED: missing {MS_SERVER}")
+        return False
+
+    with tempfile.TemporaryDirectory() as tmp:
+        staging = Path(tmp) / BUNDLE_PACKAGE_NAME
+        included, missing = stage_bundle(staging)
+        if APPLICATION_PACKAGE_DST.exists():
+            shutil.rmtree(APPLICATION_PACKAGE_DST)
+        shutil.copytree(staging, APPLICATION_PACKAGE_DST)
+
+    for year in included:
+        print(f"  OK: Contents/bin/mcp_bridge_{year}.gup")
+    for year in missing:
+        print(f"  SKIP: Contents/bin/mcp_bridge_{year}.gup (not built)")
+    print("  OK: Contents/scripts/mcp_server.ms")
+    print(f"  OK: {APPLICATION_PACKAGE_DST}")
+    return True
 
 
 def deploy_config(skip_skill: bool = False) -> bool:
-    print(f"\n[1/5] User config -> {CONFIG_DIR}")
+    print(f"\n[1/4] User config -> {CONFIG_DIR}")
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 
-    # mcp_config.ini — preserve on redeploy so custom [llm] settings + safe_mode stick
     if CONFIG_DST.exists():
-        print(f"  mcp_config.ini: preserved (already exists)")
+        print("  mcp_config.ini: preserved (already exists)")
     elif CONFIG_SRC.exists():
         shutil.copy2(CONFIG_SRC, CONFIG_DST)
-        print(f"  mcp_config.ini: installed template")
+        print("  mcp_config.ini: installed template")
     else:
         CONFIG_DST.write_text("[mcp]\nsafe_mode = true\n", "utf-8")
-        print(f"  mcp_config.ini: created default (safe_mode=true)")
+        print("  mcp_config.ini: created default (safe_mode=true)")
 
-    # .env — preserve on redeploy so the user's API key survives
     if ENV_DST.exists():
-        print(f"  .env:           preserved (already exists)")
+        print("  .env:           preserved (already exists)")
     elif ENV_SRC.exists():
         shutil.copy2(ENV_SRC, ENV_DST)
-        print(f"  .env:           installed template (edit to add OPENROUTER_API_KEY)")
+        print("  .env:           installed template (edit to add OPENROUTER_API_KEY)")
     else:
-        print(f"  .env:           SKIP (no .env.example in repo)")
+        print("  .env:           SKIP (no .env.example in repo)")
 
-    # SKILL.md — always refresh (source of truth for the in-Max chat's system prompt)
     if skip_skill:
-        print(f"  skill/SKILL.md: SKIP (--skip-skill)")
+        print("  skill/SKILL.md: SKIP (--skip-skill)")
     elif SKILL_SRC.exists():
         SKILL_DIR.mkdir(parents=True, exist_ok=True)
         shutil.copy2(SKILL_SRC, SKILL_DST)
-        print(f"  skill/SKILL.md: refreshed")
+        print("  skill/SKILL.md: refreshed")
     else:
         print(f"  skill/SKILL.md: SKIP (source not found at {SKILL_SRC})")
 
     return True
 
 
-def deploy_native_bridge(max_dir: Path) -> bool:
-    plugins_dir = max_dir / "plugins"
-    dst = plugins_dir / "mcp_bridge.gup"
-    gup_src = gup_src_for(max_dir)
-    print(f"\n[2/5] Native bridge -> {dst}")
-    year = max_year_for(max_dir)
-    if not gup_src:
-        expected = GUP_SRCS.get(year) if year else None
-        if expected:
-            print(f"  SKIP: no native bridge built for 3ds Max {year}")
-            print(f"  Expected: {expected}")
-        else:
-            print(f"  SKIP: unsupported or unknown 3ds Max version")
-        print("  MAXScript fallback will still be installed.")
-        return False
-    print(f"  Using: {gup_src.name}")
-    if copy_elevated(gup_src, dst):
-        print("  OK")
-        return True
-    print("  FAILED")
-    return False
-
-
-def deploy_maxscript(max_dir: Path) -> bool:
-    print(f"\n[3/5] MAXScript listener (TCP fallback)")
-    scripts_dir = max_dir / "scripts"
-    mcp_dir = scripts_dir / "mcp"
-    startup_dir = scripts_dir / "startup"
-
-    ok = True
-    try:
-        mcp_dir.mkdir(parents=True, exist_ok=True)
-    except PermissionError:
-        subprocess.run(
-            ["powershell", "-Command",
-             f'Start-Process -FilePath cmd.exe -ArgumentList \'/c mkdir "{mcp_dir}"\' -Verb RunAs -Wait'],
-            capture_output=True, timeout=30,
-        )
-    dst1 = mcp_dir / "mcp_server.ms"
-    dst2 = startup_dir / "mcp_autostart.ms"
-
-    if copy_elevated(MS_SERVER, dst1):
-        print(f"  OK: {dst1}")
-    else:
-        print(f"  FAILED: {dst1}")
-        ok = False
-
-    if copy_elevated(MS_AUTOSTART, dst2):
-        print(f"  OK: {dst2}")
-    else:
-        print(f"  FAILED: {dst2}")
-        ok = False
-
-    return ok
-
-
 def build_skills(skip_skill: bool = False) -> bool:
-    print(f"\n[4/5] Building skill files")
+    print("\n[3/4] Building skill files")
     if skip_skill:
         print("  SKIP (--skip-skill)")
         return True
@@ -261,9 +310,11 @@ def build_skills(skip_skill: bool = False) -> bool:
     choice = input("  Choice [2]: ").strip()
     target = {"1": "local", "3": "both"}.get(choice, "global")
     try:
-        subprocess.run([sys.executable, str(ROOT / "scripts" / "build_skill.py"),
-                        "--target", target],
-                       check=True, cwd=str(ROOT))
+        subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "build_skill.py"), "--target", target],
+            check=True,
+            cwd=str(ROOT),
+        )
         print("  OK")
         return True
     except subprocess.CalledProcessError:
@@ -351,10 +402,9 @@ def register_app_mcp_configs(repo_dir: str) -> None:
 
 
 def register_agents() -> bool:
-    print(f"\n[5/5] Agent registration")
+    print("\n[4/4] Agent registration")
     dir_str = str(ROOT)
 
-    # Detect which agents are installed
     agents = []
     for name in ["claude", "codex", "gemini"]:
         if shutil.which(name):
@@ -367,7 +417,6 @@ def register_agents() -> bool:
         print(f'    Cursor: {Path.home() / ".cursor" / "mcp.json"} (updated below if writable)')
 
     for agent in agents:
-        # Each agent CLI has different syntax
         if agent == "claude":
             cmd = f'{agent} mcp add --scope user 3dsmax-mcp -- uv run --directory "{dir_str}" 3dsmax-mcp'
         elif agent == "codex":
@@ -384,10 +433,7 @@ def register_agents() -> bool:
             print(f"  SKIP: {agent} (run manually: {cmd})")
 
     warn_if_uv_missing()
-
-    # App configs that store mcpServers (Claude Desktop, Gemini, Cursor)
     register_app_mcp_configs(dir_str)
-
     return True
 
 
@@ -402,57 +448,46 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main():
+def main() -> int:
     args = parse_args()
 
     sys.stdout.write(installer_banner())
     print(f"  3dsmax-mcp installer v{pkg_version()}\n")
 
-    # Find Max
     found = find_max_installations()
     if found:
-        max_dir = select_max(found)
-        print(f"\nUsing 3ds Max at: {max_dir}")
+        print("\nDetected 3ds Max installations:")
+        for max_dir in found:
+            year = max_year_for(max_dir)
+            label = f" ({year})" if year else ""
+            print(f"  {max_dir}{label}")
     else:
-        print("\n3ds Max not found in default locations.")
-        custom = input("Enter 3ds Max install path (or press Enter to skip): ").strip()
-        if custom:
-            max_dir = Path(custom)
-            if not (max_dir / "3dsmax.exe").exists():
-                print(f"  3dsmax.exe not found in {max_dir}")
-                max_dir = None
-        else:
-            max_dir = None
+        print("\nNo 3ds Max installations detected (2023–2027).")
 
-    # Deploy
+    if not remove_legacy_installations():
+        return 1
+
     deploy_config(skip_skill=args.skip_skill)
-    native_ok = False
-    if max_dir:
-        native_ok = deploy_native_bridge(max_dir)
-        deploy_maxscript(max_dir)
-    else:
-        print("\n[2/5] SKIP: no Max installation")
-        print("[3/5] SKIP: no Max installation")
-
+    package_ok = deploy_application_package()
     build_skills(skip_skill=args.skip_skill)
     register_agents()
 
-    # Summary
     print("\n" + "=" * 60)
     print("  done!")
     print("=" * 60)
-    if max_dir:
-       if native_ok:
-           print(f"\n  restart 3dsmax to load the native bridge.")
-       else:
-           print(f"\n  native bridge was not installed; 3dsmax will use MAXScript fallback.")
-    print(f"  the MCP server starts automatically when your agent connects.")
-    print(f"\n ")
-    print(f"\n  and thank you for installing 3dsmax-mcp! I hope you enjoy it! 3dsmax forever!!")
-
-    print(f"\n  clone // Metaverse Makers. 2026")
+    if found:
+        print("\n  restart 3ds Max to load the application package.")
+    elif package_ok:
+        print(f"\n  application package installed to {APPLICATION_PACKAGE_DST}")
+    if not package_ok:
+        print("\n  application package install failed; see messages above.")
+    print("  the MCP server starts automatically when your agent connects.")
+    print("\n ")
+    print("\n  and thank you for installing 3dsmax-mcp! I hope you enjoy it! 3dsmax forever!!")
+    print("\n  clone // Metaverse Makers. 2026")
     print()
+    return 0 if package_ok else 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/native/build.bat
+++ b/native/build.bat
@@ -40,11 +40,14 @@ if not "%MAX_VERSION%"=="2023" if not "%MAX_VERSION%"=="2024" if not "%MAX_VERSI
     exit /b 1
 )
 
-set "MAXSDK_PATH=C:\Program Files\Autodesk\3ds Max %MAX_VERSION% SDK\maxsdk"
+set "MAXSDK_ENV=ADSK_3DSMAX_SDK_%MAX_VERSION%"
+set "MAXSDK_PATH=!%MAXSDK_ENV%!"
 set "BUILD_DIR=%NATIVE_DIR%\build-%MAX_VERSION%"
 set "OUT_DIR=%NATIVE_DIR%\bin"
 set "BUILT_GUP=%BUILD_DIR%\Release\mcp_bridge.gup"
 set "STAGED_GUP=%OUT_DIR%\mcp_bridge_%MAX_VERSION%.gup"
+
+echo %MAXSDK_PATH%
 
 if not exist "%MAXSDK_PATH%\include\max.h" (
     echo Missing 3ds Max %MAX_VERSION% SDK: %MAXSDK_PATH%

--- a/native/build.bat
+++ b/native/build.bat
@@ -71,24 +71,10 @@ echo [3/3] Staging %STAGED_GUP%
 copy /Y "%BUILT_GUP%" "%STAGED_GUP%" >nul
 if errorlevel 1 exit /b 1
 
-if "%MAX_VERSION%"=="2026" (
-    copy /Y "%BUILT_GUP%" "%OUT_DIR%\mcp_bridge.gup" >nul
-    if errorlevel 1 exit /b 1
-)
-
-if "%DO_DEPLOY%"=="1" (
-    set "PLUGIN_DST=C:\Program Files\Autodesk\3ds Max %MAX_VERSION%\plugins\mcp_bridge.gup"
-    if exist "C:\Program Files\Autodesk\3ds Max %MAX_VERSION%\3dsmax.exe" (
-        echo Deploying to !PLUGIN_DST!
-        copy /Y "%STAGED_GUP%" "!PLUGIN_DST!" >nul
-        if errorlevel 1 (
-            echo Deploy failed. Run this batch file from an elevated terminal to deploy.
-            exit /b 1
-        )
-    ) else (
-        echo SKIP deploy: 3ds Max %MAX_VERSION% install not found.
-    )
-)
+set "BUNDLE_BIN=%NATIVE_DIR%\..\bundle\Contents\bin"
+if not exist "%BUNDLE_BIN%" mkdir "%BUNDLE_BIN%"
+copy /Y "%STAGED_GUP%" "%BUNDLE_BIN%\mcp_bridge_%MAX_VERSION%.gup" >nul
+if errorlevel 1 exit /b 1
 
 exit /b 0
 
@@ -99,4 +85,7 @@ exit /b 1
 
 :done
 echo.
+if "%DO_DEPLOY%"=="1" (
+    echo === Deploy: run uv run python install.py from repo root ===
+)
 echo === Done ===

--- a/scripts/stage_bundle.py
+++ b/scripts/stage_bundle.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Stage the 3dsmax-mcp ApplicationPlugins bundle from repo sources.
+
+Run:  uv run python scripts/stage_bundle.py
+      uv run python scripts/stage_bundle.py --dest bundle
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+import install  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Stage 3dsmax-mcp application package")
+    parser.add_argument(
+        "--dest",
+        default=str(ROOT / "bundle"),
+        help="Bundle root directory (default: repo bundle/)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    dest = Path(args.dest)
+    included, missing = install.stage_bundle(dest)
+    print(f"Staged bundle -> {dest}")
+    if included:
+        print(f"  GUPs: {', '.join(str(y) for y in included)}")
+    if missing:
+        print(f"  Missing: {', '.join(str(y) for y in missing)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,12 +1,165 @@
+import tempfile
+import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import install
 
 
-def test_max_year_for_reads_standard_install_folder_names() -> None:
-    assert install.max_year_for(Path(r"C:\Program Files\Autodesk\3ds Max 2023")) == 2023
-    assert install.max_year_for(Path(r"C:\Program Files\Autodesk\3ds Max 2027")) == 2027
-    assert install.max_year_for(Path(r"C:\weird\Max")) is None
+class InstallTests(unittest.TestCase):
+    def test_max_year_for_reads_standard_install_folder_names(self) -> None:
+        self.assertEqual(install.max_year_for(Path(r"C:\Program Files\Autodesk\3ds Max 2023")), 2023)
+        self.assertEqual(install.max_year_for(Path(r"C:\Program Files\Autodesk\3ds Max 2027")), 2027)
+        self.assertIsNone(install.max_year_for(Path(r"C:\weird\Max")))
+
+    def test_max_year_for_uses_installer_env_var_for_custom_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            custom = Path(tmp) / "custom-max"
+            custom.mkdir()
+            with patch.dict("os.environ", {"ADSK_3DSMAX_x64_2025": str(custom)}):
+                self.assertEqual(install.max_year_for(custom), 2025)
+
+    def test_find_max_installations_uses_env_var_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            custom = Path(tmp) / "custom-max-2026"
+            custom.mkdir()
+            (custom / "3dsmax.exe").write_text("", encoding="utf-8")
+            with patch.dict("os.environ", {"ADSK_3DSMAX_x64_2026": str(custom)}):
+                self.assertEqual(install.find_max_installations(), [custom])
+
+    def test_max_dir_for_year_prefers_env_over_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict("os.environ", {"ADSK_3DSMAX_x64_2025": tmp}):
+                self.assertEqual(install.max_dir_for_year(2025), Path(tmp))
+
+    def test_max_dir_for_year_falls_back_to_default(self) -> None:
+        env = dict(install.os.environ)
+        env.pop("ADSK_3DSMAX_x64_2025", None)
+        with patch.dict("os.environ", env, clear=True):
+            self.assertEqual(
+                install.max_dir_for_year(2025),
+                Path(r"C:\Program Files\Autodesk\3ds Max 2025"),
+            )
+
+    def test_legacy_install_paths_returns_old_format_files(self) -> None:
+        max_dir = Path(r"D:\Max\3ds Max 2025")
+        paths = install.legacy_install_paths(max_dir)
+        self.assertEqual(
+            paths,
+            [
+                max_dir / "plugins" / "mcp_bridge.gup",
+                max_dir / "scripts" / "mcp" / "mcp_server.ms",
+                max_dir / "scripts" / "startup" / "mcp_autostart.ms",
+            ],
+        )
+
+    def test_remove_legacy_installations_deletes_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            max_dir = Path(tmp) / "3ds Max 2025"
+            for rel in (
+                "plugins/mcp_bridge.gup",
+                "scripts/mcp/mcp_server.ms",
+                "scripts/startup/mcp_autostart.ms",
+            ):
+                path = max_dir / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("legacy", encoding="utf-8")
+
+            with patch.object(install, "find_max_installations", return_value=[max_dir]):
+                self.assertTrue(install.remove_legacy_installations())
+            self.assertTrue(all(not path.exists() for path in install.legacy_install_paths(max_dir)))
+
+    def test_remove_legacy_installations_fails_when_files_remain(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            max_dir = Path(tmp) / "3ds Max 2025"
+            legacy = max_dir / "plugins" / "mcp_bridge.gup"
+            legacy.parent.mkdir(parents=True)
+            legacy.write_text("locked", encoding="utf-8")
+
+            with patch.object(install, "find_max_installations", return_value=[max_dir]):
+                with patch.object(install, "delete_elevated", return_value=False):
+                    self.assertFalse(install.remove_legacy_installations())
+            self.assertTrue(legacy.exists())
+
+    def test_package_contents_xml_uses_bin_paths_and_version(self) -> None:
+        xml = install.package_contents_xml("9.9.9")
+        self.assertIn('AppVersion="9.9.9"', xml)
+        self.assertIn("./Contents/bin/mcp_bridge_2025.gup", xml)
+        self.assertIn("./Contents/scripts/mcp_server.ms", xml)
+        self.assertNotIn("plugins/", xml)
+
+    def test_stage_bundle_creates_expected_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            gup = root / "native" / "bin"
+            gup.mkdir(parents=True)
+            (gup / "mcp_bridge_2025.gup").write_bytes(b"gup")
+
+            script_src = root / "maxscript" / "mcp_server.ms"
+            script_src.parent.mkdir(parents=True)
+            script_src.write_text("-- mcp", encoding="utf-8")
+
+            patched_gups = {
+                2025: gup / "mcp_bridge_2025.gup",
+                **{year: root / f"missing_{year}.gup" for year in install.GUP_SRCS if year != 2025},
+            }
+
+            dest = root / "bundle"
+            with patch.object(install, "GUP_SRCS", patched_gups):
+                with patch.object(install, "MS_SERVER", script_src):
+                    included, missing = install.stage_bundle(dest)
+
+            self.assertEqual(included, [2025])
+            self.assertIn(2023, missing)
+            self.assertTrue((dest / "Contents" / "bin" / "mcp_bridge_2025.gup").exists())
+            self.assertTrue((dest / "Contents" / "scripts" / "mcp_server.ms").exists())
+            contents = (dest / "PackageContents.xml").read_text(encoding="utf-8")
+            self.assertIn("./Contents/bin/mcp_bridge_2025.gup", contents)
+
+    def test_native_bridge_sources_are_exact_versioned_binaries(self) -> None:
+        for year in (2023, 2024, 2025, 2026, 2027):
+            self.assertEqual(install.GUP_SRCS[year].name, f"mcp_bridge_{year}.gup")
+            self.assertEqual(
+                install.gup_src_for(Path(fr"C:\Program Files\Autodesk\3ds Max {year}")),
+                install.GUP_SRCS[year],
+            )
+        self.assertIsNone(install.gup_src_for(Path(r"C:\Program Files\Autodesk\3ds Max 2028")))
+
+    def test_claude_desktop_config_paths_include_store_and_classic(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            local_app = Path(tmp) / "LocalAppData"
+            roaming = Path(tmp) / "Roaming"
+            store_pkg = local_app / "Packages" / "Claude_pzs8sxrjxfjjc"
+            store_config = store_pkg / "LocalCache" / "Roaming" / "Claude" / "claude_desktop_config.json"
+            store_config.parent.mkdir(parents=True)
+
+            with patch.dict("os.environ", {"LOCALAPPDATA": str(local_app), "APPDATA": str(roaming)}):
+                paths = install.claude_desktop_config_paths()
+            self.assertIn(store_config, paths)
+            self.assertEqual(paths[-1], roaming / "Claude" / "claude_desktop_config.json")
+
+    def test_app_mcp_config_paths_includes_cursor_and_store_claude(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            local_app = Path(tmp) / "LocalAppData"
+            (local_app / "Packages" / "Claude_testpkg" / "LocalCache" / "Roaming" / "Claude").mkdir(
+                parents=True
+            )
+            with patch.dict(
+                "os.environ",
+                {"LOCALAPPDATA": str(local_app), "APPDATA": str(Path(tmp) / "Roaming")},
+            ):
+                labels = [label for label, _ in install.app_mcp_config_paths()]
+                paths = [path for _, path in install.app_mcp_config_paths()]
+            self.assertIn("Claude Desktop (Microsoft Store)", labels)
+            self.assertIn("Cursor", labels)
+            self.assertEqual(paths[labels.index("Cursor")], Path.home() / ".cursor" / "mcp.json")
+
+    def test_mcp_server_entry_uses_uv_run(self) -> None:
+        entry = install.mcp_server_entry(r"C:\repo\3dsmax-mcp")
+        self.assertEqual(
+            entry,
+            {"command": "uv", "args": ["run", "--directory", r"C:\repo\3dsmax-mcp", "3dsmax-mcp"]},
+        )
 
 
 def test_max_year_for_uses_installer_env_var_for_custom_paths(monkeypatch, tmp_path: Path) -> None:

--- a/uninstall.py
+++ b/uninstall.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""uninstall 3dsmax-mcp. Removes native bridge, MAXScript, skills, and agent registrations.
+"""uninstall 3dsmax-mcp. Removes application package, legacy Max files, skills, and agent registrations.
 
 Run:  uv run python uninstall.py
 """
@@ -50,12 +50,10 @@ def delete_elevated(path: Path) -> bool:
 def rmdir(path: Path):
     """Remove a directory, symlink, or junction."""
     if path.is_symlink() or path.is_junction():
-        # Symlinks/junctions: unlink the link, don't follow into target
         path.unlink()
         return
     if not path.exists():
         return
-    import shutil
     shutil.rmtree(path, ignore_errors=True)
 
 
@@ -101,7 +99,6 @@ def main():
     print("\n[2/4] Removing skill files")
     SKILL_NAME = "3dsmax-mcp-dev"
 
-    # known skill directories (real folders, symlinks, or junctions)
     skill_dirs = [
         ROOT / ".claude" / "skills" / SKILL_NAME,
         ROOT / ".agents" / "skills" / SKILL_NAME,
@@ -109,7 +106,6 @@ def main():
         Path.home() / ".agents" / "skills" / SKILL_NAME,
     ]
 
-    # also scan parent skill folders for any symlinks/junctions pointing to our skill
     scan_parents = [
         ROOT / ".claude" / "skills",
         ROOT / ".agents" / "skills",
@@ -123,13 +119,11 @@ def main():
             if entry.name == SKILL_NAME:
                 if entry not in skill_dirs:
                     skill_dirs.append(entry)
-            # Catch renamed symlinks pointing to our skill
             if entry.is_symlink() or entry.is_junction():
                 try:
                     target = str(entry.resolve())
-                    if SKILL_NAME in target:
-                        if entry not in skill_dirs:
-                            skill_dirs.append(entry)
+                    if SKILL_NAME in target and entry not in skill_dirs:
+                        skill_dirs.append(entry)
                 except Exception:
                     pass
 
@@ -139,9 +133,7 @@ def main():
             rmdir(d)
             print(f"  Removed ({kind}): {d}")
 
-    # remove generated files and .skill archives
     gen_files = [ROOT / "AGENTS.md", ROOT / f"{SKILL_NAME}.skill"]
-    # also check home for stray .skill files
     home_skill = Path.home() / ".claude" / f"{SKILL_NAME}.skill"
     if home_skill.exists():
         gen_files.append(home_skill)
@@ -151,8 +143,7 @@ def main():
             f.unlink()
             print(f"  Removed: {f}")
 
-    # 3. unregister from agents
-    print("\n[3/4] Unregistering from agents")
+    print("\n[4/5] Unregistering from agents")
     agent_cmds = {
         "claude": "claude mcp remove --scope user 3dsmax-mcp",
         "codex": "codex mcp remove 3dsmax-mcp",
@@ -168,7 +159,6 @@ def main():
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
-    # app configs that store mcpServers
     app_configs = [
         (install._claude_desktop_label(path), path)
         for path in install.claude_desktop_config_paths()
@@ -192,20 +182,20 @@ def main():
         except Exception:
             pass
 
-    # 4. clean local build artifacts
-    print("\n[4/4] Cleaning build artifacts")
+    print("\n[5/5] Cleaning build artifacts")
     for d in [ROOT / ".claude" / "skills", ROOT / ".agents" / "skills"]:
         if d.exists() and not any(d.iterdir()):
             d.rmdir()
 
     print("\n" + "=" * 60)
-    print("  deinstalled! restart 3ds Max to unload the native bridge.")
+    print("  deinstalled! restart 3ds Max to unload the bridge.")
     print("  the repo itself is untouched. you can run install.py to reinstall.")
     print(" ")
     print("  clone // Metaverse Makers. 2026 ")
     print("=" * 60)
     print()
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/uninstall.py
+++ b/uninstall.py
@@ -5,6 +5,7 @@ Run:  uv run python uninstall.py
 """
 
 import json
+import shutil
 import subprocess
 from pathlib import Path
 


### PR DESCRIPTION
Instead of copying assets to the 3ds Max installation directory, which Max greatly discourages, we will generate an app bundle and copy it to the external plugins directory (and consequently delete it when uninstalling). This would allow us to keep plugin installation files separate from Max files.

The install/uninstall keeps the old scanning paths to ensure we clean any previous installations before using the new packaging format.