### PR TITLE
lighting: add Corona provider (CoronaLight area shapes, CoronaBitmap/CoronaSky environment)

### DIFF
--- a/maxmcp/helpers/lighting.py
+++ b/maxmcp/helpers/lighting.py
@@ -13,8 +13,8 @@ from pydantic import BaseModel, ConfigDict, Field, StrictBool, model_validator
 
 from . import plugin_schema as api
 from .plugin_semantics import VRAY_LIGHT, VRAY_SHAPES, VRAY_UNITS, OCTANE_SHAPES, VRAY_IMAGE_MAPPING
-from .plugin_semantics import (CORONA_RENDERER, CORONA_LIGHT, CORONA_SKY, CORONA_BITMAP, CORONA_SHAPES,
-                               CORONA_UNITS, CORONA_COLOR_MODES, CORONA_BITMAP_MAPPING)
+from .plugin_semantics import (CORONA_RENDERER, CORONA_LIGHT, CORONA_SUN, CORONA_MOON, CORONA_SKY, CORONA_BITMAP,
+                               CORONA_SHAPES, CORONA_UNITS, CORONA_COLOR_MODES, CORONA_SUN_COLOR_MODES, CORONA_BITMAP_MAPPING)
 
 LIGHT, MAP, RENDERER = 48, 3088, 3840
 OCTANE_LIGHT = (592523983, 1640440069)
@@ -98,7 +98,8 @@ class EnvironmentSource(Strict):
 
 class LightSpec(Strict):
     name: str = ""
-    kind: Literal["area", "point", "environment"]
+    kind: Literal["area", "point", "environment", "directional"]
+    body: Literal["sun", "moon"] | None = None  # directional only; defaults to sun
     shape: Literal["rectangle", "disk", "sphere", "cylinder"] | None = None
     size: LightSize | None = None
     position: Vector3 | None = None
@@ -111,9 +112,14 @@ class LightSpec(Strict):
 
     @model_validator(mode="after")
     def compatible_fields(self):
+        if self.kind != "directional" and self.body is not None:
+            raise ValueError("Only directional lights take a body (sun or moon).")
         if self.kind == "environment":
             if self.environment is None or any(x is not None for x in (self.shape, self.size, self.position, self.orientation, self.color)):
                 raise ValueError("Environment requires an environment source, without finite emitter/color fields.")
+        elif self.kind == "directional":
+            if self.orientation is None or any(x is not None for x in (self.shape, self.size, self.environment)):
+                raise ValueError("Directional lights require orientation, without shape, size or environment source.")
         else:
             if self.environment is not None:
                 raise ValueError("Only environment lights accept an environment source.")
@@ -241,6 +247,12 @@ def compile_lights(specs: list[LightSpec], context: dict, family: str, unit="sce
         if spec.kind == "environment":
             compile_environment(plan, key, spec, family)
             plan.lights.append({"id": key, "kind": "environment", "family": family})
+            continue
+        if spec.kind == "directional":
+            if family != "corona":
+                raise ValueError("Directional sun/moon lights currently have a verified provider for Corona only.")
+            compile_corona_directional(plan, key, spec, scale)
+            plan.lights.append({"id": key, "kind": "directional", "family": family})
             continue
         shape = spec.shape or "point"
         color = spec.color or LightColor(kelvin=6500)
@@ -371,6 +383,34 @@ def compile_environment(plan: Plan, key: str, spec: LightSpec, family: str):
         plan.payload["environment"] = {"owner_ref": {"created": key}, "replace_existing": source.replace_existing}
 
 
+def compile_corona_directional(plan: Plan, key: str, spec: LightSpec, scale: float):
+    """CoronaSun / CoronaMoon: shapeless directional emitters that shine down the node's
+    local -Z (verified by render). Intensity is Corona's own multiplier. The sun keeps
+    Corona's realistic colour unless a Kelvin or RGB colour is given; the moon only has
+    an RGB filter. Size multiplier, phase and sky linking stay at plugin defaults."""
+    body = spec.body or "sun"
+    if spec.output.unit != "renderer":
+        raise ValueError("Corona sun/moon intensity is a renderer multiplier; use unit renderer.")
+    if not spec.cast_shadows:
+        raise ValueError("Corona lights always cast shadows; there is no per-light shadow switch.")
+    color = spec.color
+    if body == "sun":
+        plan.create(key, CORONA_SUN, name=spec.name, matrix=world_matrix(spec, scale))
+        mode = "realistic" if color is None else "kelvin" if color.kelvin is not None else "rendering_rgb"
+        for name, value in {"on": spec.enabled, "targeted": False, "intensity": spec.output.value,
+                            "colorMode": CORONA_SUN_COLOR_MODES[mode]}.items():
+            plan.set(key, name, value)
+        if mode == "kelvin": plan.set(key, "blackbodyTemperature", color.kelvin)
+        elif mode == "rendering_rgb": plan.set(key, "colorDirect", list(color.rgb))
+    else:
+        if color is not None and color.kelvin is not None:
+            raise ValueError("CoronaMoon has an RGB colour filter only; supply rgb or omit colour.")
+        plan.create(key, CORONA_MOON, name=spec.name, matrix=world_matrix(spec, scale))
+        for name, value in {"on": spec.enabled, "targeted": False, "intensity": spec.output.value}.items():
+            plan.set(key, name, value)
+        if color is not None: plan.set(key, "colorFilter", list(color.rgb))
+
+
 def compile_corona_environment(plan: Plan, key: str, spec: LightSpec):
     """Corona lights the scene from the 3ds Max environment slot itself: a CoronaBitmap
     (HDRI) or an existing map such as CoronaSky is bound there directly, without a dome
@@ -413,7 +453,8 @@ def capabilities(requested="current", detail="summary") -> dict:
     result = {"renderer": chosen, "provider": family, "context_token": context["context_token"],
               "meters_per_unit": context["meters_per_unit"], "color_management": context["color_management"],
               "renderers": [{"name": r["name"], "label": r["label"], "provider": RENDERER_FAMILIES.get(tuple(r["class_id"]))} for r in context["renderers"]],
-              "kinds": ["area"] + (["point"] if family == "photometric" else ["environment"]),
+              "kinds": ["area"] + (["point"] if family == "photometric" else ["environment"]) + (["directional"] if family == "corona" else []),
+              **({"directional_bodies": ["sun", "moon"]} if family == "corona" else {}),
               "area_shapes": list(PHOTOMETRIC)[1:] if family == "photometric" else list(OCTANE_SHAPES) if family == "octane" else list(CORONA_SHAPES) if family == "corona" else ["rectangle", "disk", "sphere"],
               "output_units": ["cd"] if family == "photometric" else ["renderer"] if family == "octane" else list(CORONA_UNITS) if family == "corona" else list(VRAY_UNITS),
               "color_modes": ["kelvin"] if family == "octane" else ["kelvin", "rendering_rgb"],
@@ -425,7 +466,7 @@ def capabilities(requested="current", detail="summary") -> dict:
     if family == "corona":
         result["notes"] = ["Corona lights always cast shadows (cast_shadows=false is refused).",
                            "Environment binds the map itself to the scene environment slot at output 1.0.",
-                           "CoronaSun and CoronaMoon (directional, shapeless) need a directional light kind in LightSpec and are not part of this provider yet."]
+                           "Directional kind creates CoronaSun (body sun, default) or CoronaMoon (body moon); output is Corona's multiplier, orientation is the emission direction. Sky linking, size multiplier and moon phase stay at plugin defaults."]
     if detail == "full": result["light_spec_schema"] = LightSpec.model_json_schema()
     return result
 
@@ -461,7 +502,7 @@ def create(specs, requested="current", unit="scene", expected_context=None) -> d
 def inspect_one(owner_ref: dict, family: str | None = None) -> dict:
     identity = api.inspect(owner_ref=owner_ref, fields=["__identity_only__"], limit=1)
     ids = tuple(identity["identity"]["class_id"])
-    detected = "vray" if ids == VRAY_LIGHT else "octane" if ids in {OCTANE_LIGHT, OCTANE_ENV} else "photometric" if ids in PHOTOMETRIC.values() else "corona" if ids in {CORONA_LIGHT, CORONA_BITMAP, CORONA_SKY} else None
+    detected = "vray" if ids == VRAY_LIGHT else "octane" if ids in {OCTANE_LIGHT, OCTANE_ENV} else "photometric" if ids in PHOTOMETRIC.values() else "corona" if ids in {CORONA_LIGHT, CORONA_SUN, CORONA_MOON, CORONA_BITMAP, CORONA_SKY} else None
     if family is not None and family != detected:
         raise ValueError("Light reference provider does not match its actual class.")
     family = detected
@@ -474,6 +515,8 @@ def inspect_one(owner_ref: dict, family: str | None = None) -> dict:
                    "tubeAnalyticLightCapRadius", "tubeAnalyticLightLength", "emission", "normalize", "power", "texture_tex", "texture_input_type", "rotation"],
         "corona": (["on", "shape", "intensity", "intensityUnits", "colorMode", "color", "blackbodyTemp", "texmap", "width", "height",
                     "targeted", "twosidedEmission", "visibleDirectly", "directionality"] if ids == CORONA_LIGHT
+                   else ["on", "intensity", "colorMode", "colorDirect", "blackbodyTemperature", "sizeMultiplier", "targeted"] if ids == CORONA_SUN
+                   else ["on", "intensity", "colorFilter", "sizeMultiplier", "phase", "targeted"] if ids == CORONA_MOON
                    else ["filename", "enviroMapping", "gamma", "colorSpace", "wAngle"] if ids == CORONA_BITMAP
                    else ["intensityMultiplier", "skyModel", "turbidity", "sunSelectionMode", "selectedSun", "cloudsEnable"]),
     }.get(family, ["__identity_only__"])
@@ -527,6 +570,17 @@ def inspect_one(owner_ref: dict, family: str | None = None) -> dict:
                              else {"radius": value("width")} if shape else None)
             state["two_sided"] = value("twosidedEmission")
             state["directionality"] = value("directionality")
+        elif ids in {CORONA_SUN, CORONA_MOON}:
+            body = "sun" if ids == CORONA_SUN else "moon"
+            if body == "sun":
+                mode = value("colorMode")
+                color = ({"kelvin": value("blackbodyTemperature")} if mode == 1 else
+                         {"rgb": value("colorDirect"), "space": "rendering"} if mode == 0 else {"realistic": True})
+            else:
+                color = {"rgb": value("colorFilter"), "space": "rendering", "filter": True}
+            state.update(kind="directional", body=body, enabled=value("on"), cast_shadows=True, color=color,
+                         output={"value": value("intensity"), "unit": "renderer"}, size_multiplier=value("sizeMultiplier"))
+            if body == "moon": state["phase"] = value("phase")
         else:
             # The map itself is the environment light; there is no wrapper node.
             state.update(kind="environment",
@@ -621,6 +675,9 @@ def edit(edits: list[dict], unit="scene") -> dict:
                     if output.unit != "renderer" or "intensityMultiplier" not in {p["name"] for p in state["bindings"]}:
                         raise ValueError("Only a CoronaSky environment exposes an intensity multiplier; a CoronaBitmap environment has none.")
                     assign("intensityMultiplier", output.value)
+                elif state["kind"] == "directional":
+                    if output.unit != "renderer": raise ValueError("Corona sun/moon intensity is a renderer multiplier.")
+                    assign("intensity", output.value)
                 else:
                     if output.unit not in CORONA_UNITS: raise ValueError("Corona output accepts renderer, lm or cd.")
                     assign("intensityUnits", CORONA_UNITS[output.unit]); assign("intensity", output.value)
@@ -636,6 +693,12 @@ def edit(edits: list[dict], unit="scene") -> dict:
             elif family == "photometric":
                 assign("useKelvin", color.kelvin is not None)
                 assign("kelvin" if color.kelvin is not None else "rgb", color.kelvin if color.kelvin is not None else list(color.rgb))
+            elif family == "corona" and state.get("body") == "sun":
+                assign("colorMode", CORONA_SUN_COLOR_MODES["kelvin" if color.kelvin is not None else "rendering_rgb"])
+                assign("blackbodyTemperature" if color.kelvin is not None else "colorDirect", color.kelvin if color.kelvin is not None else list(color.rgb))
+            elif family == "corona" and state.get("body") == "moon":
+                if color.kelvin is not None: raise ValueError("CoronaMoon has an RGB colour filter only.")
+                assign("colorFilter", list(color.rgb))
             elif family == "corona":
                 assign("colorMode", CORONA_COLOR_MODES["kelvin" if color.kelvin is not None else "rendering_rgb"])
                 assign("blackbodyTemp" if color.kelvin is not None else "color", color.kelvin if color.kelvin is not None else list(color.rgb))

--- a/maxmcp/helpers/lighting.py
+++ b/maxmcp/helpers/lighting.py
@@ -13,6 +13,8 @@ from pydantic import BaseModel, ConfigDict, Field, StrictBool, model_validator
 
 from . import plugin_schema as api
 from .plugin_semantics import VRAY_LIGHT, VRAY_SHAPES, VRAY_UNITS, OCTANE_SHAPES, VRAY_IMAGE_MAPPING
+from .plugin_semantics import (CORONA_RENDERER, CORONA_LIGHT, CORONA_SKY, CORONA_BITMAP, CORONA_SHAPES,
+                               CORONA_UNITS, CORONA_COLOR_MODES, CORONA_BITMAP_MAPPING)
 
 LIGHT, MAP, RENDERER = 48, 3088, 3840
 OCTANE_LIGHT = (592523983, 1640440069)
@@ -28,7 +30,9 @@ PHOTOMETRIC = {
 RENDERER_FAMILIES = {
     (1941615238, 2012806412): "vray", (1770671000, 1323107829): "vray",
     (2717442453, 1319335807): "octane", (1, 0): "photometric",
+    CORONA_RENDERER: "corona",
 }
+FAMILY_NAMES = {"vray", "octane", "photometric", "corona"}
 
 
 class Strict(BaseModel):
@@ -141,7 +145,7 @@ def renderer(context: dict, requested: str) -> tuple[str, dict]:
         chosen = context["renderer"]
     else:
         candidates = [r for r in available if requested.lower() in {r["name"].lower(), r["label"].lower()}]
-        if not candidates and requested in {"vray", "octane", "photometric"}:
+        if not candidates and requested in FAMILY_NAMES:
             candidates = [r for r in available if RENDERER_FAMILIES.get(tuple(r["class_id"])) == requested]
         if len(candidates) != 1:
             raise ValueError("Choose an exact renderer name from lighting_capabilities; renderer selection is ambiguous or unavailable.")
@@ -196,6 +200,7 @@ class Plan:
         self.schemas: dict[str, dict] = {}
         self.class_schemas: dict[tuple, dict] = {}
         self.lights = []
+        self.existing: dict[str, dict] = {}  # plan ids bound to pre-existing owners (no create)
 
     def create(self, resource_id: str, ids, superclass=LIGHT, name="", matrix=None):
         ref = class_ref(ids, superclass)
@@ -287,6 +292,25 @@ def compile_lights(specs: list[LightSpec], context: dict, family: str, unit="sce
             elif shape == "sphere": plan.set(key, "sphereAnalyticLightRadius", size["radius"])
             else:
                 plan.set(key, "tubeAnalyticLightCapRadius", size["radius"]); plan.set(key, "tubeAnalyticLightLength", size["length"])
+        elif family == "corona":
+            if shape not in CORONA_SHAPES or spec.output.unit not in CORONA_UNITS:
+                raise ValueError("Corona supports rectangle/disk/sphere/cylinder emitters with renderer, lm or cd output.")
+            if not spec.cast_shadows:
+                raise ValueError("Corona lights always cast shadows; there is no per-light shadow switch.")
+            plan.create(key, CORONA_LIGHT, name=spec.name, matrix=world_matrix(spec, scale))
+            for name, value in {"shape": CORONA_SHAPES[shape], "on": spec.enabled, "targeted": False,
+                                "intensityUnits": CORONA_UNITS[spec.output.unit], "intensity": spec.output.value,
+                                "colorMode": CORONA_COLOR_MODES["kelvin" if color.kelvin is not None else "rendering_rgb"],
+                                "twosidedEmission": False}.items():
+                plan.set(key, name, value)
+            plan.set(key, "blackbodyTemp" if color.kelvin is not None else "color", color.kelvin if color.kelvin is not None else list(color.rgb))
+            # Corona width is the local X extent for rectangles and the radius otherwise;
+            # height is the local Y extent for rectangles and the length for cylinders.
+            if shape == "rectangle":
+                plan.set(key, "width", size["width"]); plan.set(key, "height", size["height"])
+            else:
+                plan.set(key, "width", size["radius"])
+                if shape == "cylinder": plan.set(key, "height", size["length"])
         plan.lights.append({"id": key, "kind": spec.kind, "family": family})
     return plan
 
@@ -297,6 +321,8 @@ def compile_environment(plan: Plan, key: str, spec: LightSpec, family: str):
         raise ValueError("Environment output uses an explicit renderer multiplier.")
     if family == "photometric":
         raise ValueError("Scanline environment lighting needs a separate validated skylight provider; a background map alone is not illumination.")
+    if family == "corona":
+        return compile_corona_environment(plan, key, spec)
     if source.kind == "existing_map":
         if source.rotation != 0 or source.source_color_space is not None:
             raise ValueError("Inspect and edit an existing map's rotation/color settings explicitly; it may be shared.")
@@ -345,6 +371,39 @@ def compile_environment(plan: Plan, key: str, spec: LightSpec, family: str):
         plan.payload["environment"] = {"owner_ref": {"created": key}, "replace_existing": source.replace_existing}
 
 
+def compile_corona_environment(plan: Plan, key: str, spec: LightSpec):
+    """Corona lights the scene from the 3ds Max environment slot itself: a CoronaBitmap
+    (HDRI) or an existing map such as CoronaSky is bound there directly, without a dome
+    node or wrapper. The slot has no multiplier, so output stays at the explicit 1.0."""
+    source = spec.environment
+    if "environment" in plan.payload:
+        raise ValueError("Only one scene environment binding can be created in a batch.")
+    if not spec.enabled:
+        raise ValueError("Disabled scene-environment creation is not supported; create or edit its binding explicitly.")
+    if spec.output.value != 1:
+        raise ValueError("The Corona scene environment has no multiplier; bind at 1.0 and edit the map's own intensity (CoronaSky intensityMultiplier, or a CoronaColorCorrect) explicitly.")
+    if source.kind == "existing_map":
+        if source.rotation != 0 or source.source_color_space is not None:
+            raise ValueError("Inspect and edit an existing map's rotation/color settings explicitly; it may be shared.")
+        plan.existing[key] = source.owner_ref
+        plan.payload["environment"] = {"owner_ref": source.owner_ref, "replace_existing": source.replace_existing}
+        return
+    path = Path(source.path).expanduser().resolve()
+    if not path.is_file():
+        raise ValueError(f"Environment asset not found: {path}")
+    if path.suffix.lower() not in {".exr", ".hdr"}:
+        raise ValueError("HDRI creation currently accepts scene-linear EXR/HDR; use an inspected existing map for other encodings.")
+    if source.rotation != 0:
+        raise ValueError("Corona HDRI rotation is not a verified binding yet; rotate the created CoronaBitmap explicitly after inspecting it.")
+    if source.source_color_space:
+        raise ValueError("Corona input primaries override needs a verified mapping; use an inspected existing map for an explicit color space.")
+    plan.create(key, CORONA_BITMAP, MAP)
+    plan.set(key, "filename", str(path))
+    plan.set(key, "enviroMapping", CORONA_BITMAP_MAPPING["spherical"])
+    plan.set(key, "gamma", 1.0)  # Linear samples: no input transfer curve.
+    plan.payload["environment"] = {"owner_ref": {"created": key}, "replace_existing": source.replace_existing}
+
+
 def capabilities(requested="current", detail="summary") -> dict:
     if detail not in {"summary", "full"}: raise ValueError("detail must be summary or full")
     context = api.native("native:lighting_context", {})
@@ -355,14 +414,18 @@ def capabilities(requested="current", detail="summary") -> dict:
               "meters_per_unit": context["meters_per_unit"], "color_management": context["color_management"],
               "renderers": [{"name": r["name"], "label": r["label"], "provider": RENDERER_FAMILIES.get(tuple(r["class_id"]))} for r in context["renderers"]],
               "kinds": ["area"] + (["point"] if family == "photometric" else ["environment"]),
-              "area_shapes": list(PHOTOMETRIC)[1:] if family == "photometric" else list(OCTANE_SHAPES) if family == "octane" else ["rectangle", "disk", "sphere"],
-              "output_units": ["cd"] if family == "photometric" else ["renderer"] if family == "octane" else list(VRAY_UNITS),
+              "area_shapes": list(PHOTOMETRIC)[1:] if family == "photometric" else list(OCTANE_SHAPES) if family == "octane" else list(CORONA_SHAPES) if family == "corona" else ["rectangle", "disk", "sphere"],
+              "output_units": ["cd"] if family == "photometric" else ["renderer"] if family == "octane" else list(CORONA_UNITS) if family == "corona" else list(VRAY_UNITS),
               "color_modes": ["kelvin"] if family == "octane" else ["kelvin", "rendering_rgb"],
-              "environment_route": None if family == "photometric" else "scene_environment_map" if family == "octane" else "dome_node",
+              "environment_route": None if family == "photometric" else "scene_environment_map" if family in {"octane", "corona"} else "dome_node",
               "environment_sources": [] if family == "photometric" else ["linear_exr_hdr", "existing_map_including_procedural_sky"],
               "color_policy": {"float_images": "linear samples; no extra input gamma", "primaries": "renderer input color-space policy or explicit source_color_space where supported", "rendering_space": context["color_management"].get("rendering_space"), "exposure_changes": False},
               "verification": "development_pending_live_validation",
               "unsupported": ["automatic renderer switching", "implicit controller replacement", "automatic exposure", "unverified physical conversions"]}
+    if family == "corona":
+        result["notes"] = ["Corona lights always cast shadows (cast_shadows=false is refused).",
+                           "Environment binds the map itself to the scene environment slot at output 1.0.",
+                           "CoronaSun and CoronaMoon (directional, shapeless) need a directional light kind in LightSpec and are not part of this provider yet."]
     if detail == "full": result["light_spec_schema"] = LightSpec.model_json_schema()
     return result
 
@@ -378,7 +441,11 @@ def create(specs, requested="current", unit="scene", expected_context=None) -> d
     resources = {r["id"]: r for r in applied["resources"]}
     actual = []
     for item in plan.lights:
-        resource = resources[item["id"]]
+        resource = resources.get(item["id"])
+        if resource is None:
+            if item["id"] not in plan.existing:
+                raise RuntimeError(f"Native commit returned no resource for {item['id']!r}.")
+            resource = {"id": item["id"], "owner_ref": dict(plan.existing[item["id"]])}
         resource["owner_ref"] = {**resource["owner_ref"], "root_binding":
             {"node": resource["node_ref"], "scope": "base_object"} if resource.get("node_ref") else {"root": "environment"}}
         entry = {"light_ref": {"owner_ref": resource["owner_ref"], "node_ref": resource.get("node_ref"), "provider": family}}
@@ -394,7 +461,7 @@ def create(specs, requested="current", unit="scene", expected_context=None) -> d
 def inspect_one(owner_ref: dict, family: str | None = None) -> dict:
     identity = api.inspect(owner_ref=owner_ref, fields=["__identity_only__"], limit=1)
     ids = tuple(identity["identity"]["class_id"])
-    detected = "vray" if ids == VRAY_LIGHT else "octane" if ids in {OCTANE_LIGHT, OCTANE_ENV} else "photometric" if ids in PHOTOMETRIC.values() else None
+    detected = "vray" if ids == VRAY_LIGHT else "octane" if ids in {OCTANE_LIGHT, OCTANE_ENV} else "photometric" if ids in PHOTOMETRIC.values() else "corona" if ids in {CORONA_LIGHT, CORONA_BITMAP, CORONA_SKY} else None
     if family is not None and family != detected:
         raise ValueError("Light reference provider does not match its actual class.")
     family = detected
@@ -405,6 +472,10 @@ def inspect_one(owner_ref: dict, family: str | None = None) -> dict:
                         "light_width", "light_length", "light_radius"],
         "octane": ["enabled", "analyticLightType", "quadAnalyticLightSize", "diskAnalyticLightSize", "sphereAnalyticLightRadius",
                    "tubeAnalyticLightCapRadius", "tubeAnalyticLightLength", "emission", "normalize", "power", "texture_tex", "texture_input_type", "rotation"],
+        "corona": (["on", "shape", "intensity", "intensityUnits", "colorMode", "color", "blackbodyTemp", "texmap", "width", "height",
+                    "targeted", "twosidedEmission", "visibleDirectly", "directionality"] if ids == CORONA_LIGHT
+                   else ["filename", "enviroMapping", "gamma", "colorSpace", "wAngle"] if ids == CORONA_BITMAP
+                   else ["intensityMultiplier", "skyModel", "turbidity", "sunSelectionMode", "selectedSun", "cloudsEnable"]),
     }.get(family, ["__identity_only__"])
     data = api.inspect(owner_ref=identity["owner_ref"], fields=fields, limit=64)
     ids = tuple(data["identity"]["class_id"])
@@ -443,6 +514,25 @@ def inspect_one(owner_ref: dict, family: str | None = None) -> dict:
                 state["overrides"] = {k: v for k,v in emission_values.items() if k.endswith("VT") and v is not None}
             dims = value("quadAnalyticLightSize") if shape == "rectangle" else value("diskAnalyticLightSize")
             state["size"] = {"width": dims[0], "height": dims[1]} if shape == "rectangle" and dims and len(dims) == 2 else {"radius": value("sphereAnalyticLightRadius")} if shape == "sphere" else {"radius": value("tubeAnalyticLightCapRadius"), "length": value("tubeAnalyticLightLength")} if shape == "cylinder" else {"diameters": dims} if shape == "disk" else None
+    elif family == "corona":
+        if ids == CORONA_LIGHT:
+            shape = next((k for k, v in CORONA_SHAPES.items() if v == value("shape")), None)
+            mode = value("colorMode")
+            unit = next((k for k, v in CORONA_UNITS.items() if v == value("intensityUnits")), "lx" if value("intensityUnits") == 3 else None)
+            state.update(kind="area" if shape else None, shape=shape, enabled=value("on"), cast_shadows=True,
+                         color={"kelvin": value("blackbodyTemp")} if mode == 1 else {"rgb": value("color"), "space": "rendering"} if mode == 0 else {"texmap": value("texmap")},
+                         output={"value": value("intensity"), "unit": unit})
+            state["size"] = ({"width": value("width"), "height": value("height")} if shape == "rectangle"
+                             else {"radius": value("width"), "length": value("height")} if shape == "cylinder"
+                             else {"radius": value("width")} if shape else None)
+            state["two_sided"] = value("twosidedEmission")
+            state["directionality"] = value("directionality")
+        else:
+            # The map itself is the environment light; there is no wrapper node.
+            state.update(kind="environment",
+                         output={"value": value("intensityMultiplier") if ids == CORONA_SKY else 1.0, "unit": "renderer"})
+            state["environment_source"] = {"class_ref": {"superclass_id": MAP, "class_id": list(ids)},
+                                           "values": {p["name"]: p.get("value") for p in data["properties"] if p.get("value_status") == "read"}}
     state["decoded"] = family is not None and state.get("kind") is not None
     state["unreadable"] = [{"name": p["name"], "status": p.get("value_status")} for p in data["properties"] if p.get("value_status") != "read"]
     state["light_token"] = {"owner_ref": data["owner_ref"], "schema_token": data["schema_token"], "state_token": data["state_token"]}
@@ -510,8 +600,11 @@ def edit(edits: list[dict], unit="scene") -> dict:
                 continue
             if type(changes[name]) is not bool:
                 raise ValueError(f"{name} must be boolean.")
-            if family == "octane" and state["kind"] == "environment":
+            if family in {"octane", "corona"} and state["kind"] == "environment":
                 raise ValueError("Environment binding enable/shadow changes are not emitter parameters.")
+            if family == "corona" and name == "cast_shadows":
+                if changes[name] is False: raise ValueError("Corona lights always cast shadows; there is no per-light shadow switch.")
+                continue
             assign("enabled" if family == "octane" and name == "enabled" else "on" if name == "enabled" else "castShadows",
                    changes[name], emission=family == "octane" and name == "cast_shadows")
         if "output" in changes:
@@ -523,6 +616,14 @@ def edit(edits: list[dict], unit="scene") -> dict:
             elif family == "photometric":
                 if output.unit != "cd": raise ValueError("Photometric intensity accepts cd.")
                 assign("useMultiplier", False); assign("intensityType", 1); assign("intensity", output.value)
+            elif family == "corona":
+                if state["kind"] == "environment":
+                    if output.unit != "renderer" or "intensityMultiplier" not in {p["name"] for p in state["bindings"]}:
+                        raise ValueError("Only a CoronaSky environment exposes an intensity multiplier; a CoronaBitmap environment has none.")
+                    assign("intensityMultiplier", output.value)
+                else:
+                    if output.unit not in CORONA_UNITS: raise ValueError("Corona output accepts renderer, lm or cd.")
+                    assign("intensityUnits", CORONA_UNITS[output.unit]); assign("intensity", output.value)
             else:
                 if output.unit != "renderer": raise ValueError("Octane output accepts renderer power.")
                 assign("power", output.value, emission=state["kind"] != "environment")
@@ -535,6 +636,9 @@ def edit(edits: list[dict], unit="scene") -> dict:
             elif family == "photometric":
                 assign("useKelvin", color.kelvin is not None)
                 assign("kelvin" if color.kelvin is not None else "rgb", color.kelvin if color.kelvin is not None else list(color.rgb))
+            elif family == "corona":
+                assign("colorMode", CORONA_COLOR_MODES["kelvin" if color.kelvin is not None else "rendering_rgb"])
+                assign("blackbodyTemp" if color.kelvin is not None else "color", color.kelvin if color.kelvin is not None else list(color.rgb))
             else:
                 if color.kelvin is None: raise ValueError("This Octane emission provider accepts Kelvin.")
                 assign("temperature", color.kelvin, emission=True)
@@ -552,6 +656,11 @@ def edit(edits: list[dict], unit="scene") -> dict:
                 else:
                     assign("light_radius", dims["radius"])
                     if shape == "cylinder": assign("light_length", dims["length"])
+            elif family == "corona":
+                if shape == "rectangle": assign("width", dims["width"]); assign("height", dims["height"])
+                else:
+                    assign("width", dims["radius"])
+                    if shape == "cylinder": assign("height", dims["length"])
             elif shape == "rectangle": assign("quadAnalyticLightSize", [dims["width"], dims["height"]])
             elif shape == "disk": assign("diskAnalyticLightSize", [2*dims["radius"], 2*dims["radius"]])
             elif shape == "sphere": assign("sphereAnalyticLightRadius", dims["radius"])

--- a/maxmcp/helpers/plugin_semantics.py
+++ b/maxmcp/helpers/plugin_semantics.py
@@ -16,6 +16,7 @@ VRAY_IMAGE_MAPPING = {"angular": 0, "cubic": 1, "spherical": 2, "mirrored_ball":
 CORONA_RENDERER = (1655201228, 1379677700)
 CORONA_LIGHT = (1110459877, 692869241)
 CORONA_SUN = (2084191360, 164583279)
+CORONA_MOON = (1510691909, 443094578)   # colour filter only, no Kelvin/realistic modes
 CORONA_SKY = (1498904930, 1286306497)
 CORONA_BITMAP = (2881116036, 1699234372)
 CORONA_SHAPES = {"sphere": 0, "rectangle": 1, "disk": 2, "cylinder": 3}

--- a/maxmcp/helpers/plugin_semantics.py
+++ b/maxmcp/helpers/plugin_semantics.py
@@ -6,6 +6,31 @@ OCTANE_LIGHT = (592523983, 1640440069)
 OCTANE_SHAPES = {"rectangle": 0, "disk": 1, "sphere": 3, "cylinder": 4}
 VRAY_IMAGE = (1734939723, 46203261)
 VRAY_IMAGE_MAPPING = {"angular": 0, "cubic": 1, "spherical": 2, "mirrored_ball": 3, "max_standard": 4}
+
+# Corona Renderer (Chaos). Class IDs read from live PB2 descriptors on Corona 15 / 3ds Max 2027.
+# Enum meanings come from Chaos's own coronaConverter.ms shipped with Corona
+# (<Corona>\Scripts\coronaConverter.ms): units at line 3354, colorMode at 3379,
+# shape at 3410-3546, CoronaBitmap enviroMapping at 45-46, CoronaSun colorMode at 3744-3746.
+# Shape geometry (width = X extent or radius, height = Y extent or cylinder length) was
+# confirmed from live bounding boxes of a CoronaLight per shape value.
+CORONA_RENDERER = (1655201228, 1379677700)
+CORONA_LIGHT = (1110459877, 692869241)
+CORONA_SUN = (2084191360, 164583279)
+CORONA_SKY = (1498904930, 1286306497)
+CORONA_BITMAP = (2881116036, 1699234372)
+CORONA_SHAPES = {"sphere": 0, "rectangle": 1, "disk": 2, "cylinder": 3}
+CORONA_UNITS = {"renderer": 0, "lm": 1, "cd": 2}          # 3 = lux, not offered by LightOutput
+CORONA_COLOR_MODES = {"rendering_rgb": 0, "kelvin": 1, "texmap": 2}
+CORONA_SUN_COLOR_MODES = {"rendering_rgb": 0, "kelvin": 1, "realistic": 2}
+CORONA_BITMAP_MAPPING = {"spherical": 0, "screen": 1}
+_CORONA_EVIDENCE = "Chaos coronaConverter.ms shipped with Corona 15 (units L3354, colorMode L3379, shape L3410-3546)"
+_CORONA_LIGHT_DOMAINS = {
+    (0, 121, "shape"): CORONA_SHAPES,
+    (0, 132, "colorMode"): CORONA_COLOR_MODES,
+    (0, 136, "intensityUnits"): {**CORONA_UNITS, "lx": 3},
+}
+_CORONA_SUN_DOMAINS = {(0, 107, "colorMode"): CORONA_SUN_COLOR_MODES}
+_CORONA_BITMAP_DOMAINS = {(0, 102, "enviroMapping"): CORONA_BITMAP_MAPPING}
 _VRAY_IMAGE_DOMAINS = {
     (0, 2, "mapType"): VRAY_IMAGE_MAPPING,
     (0, 25, "color_space"): {"none": 0, "inverse_gamma": 1, "srgb": 2, "from_max": 3, "auto": 4},
@@ -32,6 +57,12 @@ def annotate(data: dict) -> dict:
         domains,evidence={(0,14768,"analyticLightType"):OCTANE_SHAPES},"Octane 2026.3 Type combo item data (Quad=0, Disc=1, Sphere=3, Tube=4)"
     elif superclass==3088 and ids==VRAY_IMAGE:
         domains,evidence=_VRAY_IMAGE_DOMAINS,"V-Ray 7 update 3 VRayBitmap Qt combo item data (mapping, transfer function and RGB primaries)"
+    elif superclass==48 and ids==CORONA_LIGHT:
+        domains,evidence=_CORONA_LIGHT_DOMAINS,_CORONA_EVIDENCE
+    elif superclass==48 and ids==CORONA_SUN:
+        domains,evidence=_CORONA_SUN_DOMAINS,"Chaos coronaConverter.ms shipped with Corona 15 (L3744-3746: colorMode 0 = direct colour; PB2 default 2 = realistic)"
+    elif superclass==3088 and ids==CORONA_BITMAP:
+        domains,evidence=_CORONA_BITMAP_DOMAINS,"Chaos coronaConverter.ms shipped with Corona 15 (L45-46: CORONA_BITMAP_MAPPING_SPHERICAL=0, SCREEN=1)"
     else:
         return data
     for property in data.get("properties", []):


### PR DESCRIPTION
## What

Adds a `corona` lighting family so `lighting_capabilities` / `create_lights` / `inspect_lights` / `edit_lights` work with Corona Renderer, which previously returned "No verified lighting provider for Corona".

- **Area lights** via `CoronaLight`: rectangle, disk, sphere, cylinder. Output units `renderer` (Corona default), `lm`, `cd`. Colour as Kelvin (`colorMode=1`, `blackbodyTemp`) or scene-linear RGB (`colorMode=0`, `color`). Position/aim through the shared `world_matrix`.
- **Environment** via the 3ds Max environment slot itself (no dome node in Corona): HDRI → `CoronaBitmap` (spherical mapping, gamma 1.0), or `existing_map` (e.g. a `CoronaSky`) bound as-is. Output must be 1.0 because the slot has no multiplier; a `CoronaSky` intensity is editable through `edit_lights`.
- Enum domains for `CoronaLight` (shape / colorMode / intensityUnits), `CoronaSun` (colorMode) and `CoronaBitmap` (enviroMapping) are published through `plugin_semantics.annotate`.

Refused explicitly rather than guessed: `point` kind, `cd/m2` and `lx`, `cast_shadows=false` (Corona lights have no per-light shadow switch), HDRI rotation and colour-space overrides (bindings not verified yet), disabled environment creation.

- **Directional** kind (new in `LightSpec`, `body: sun | moon`, default sun): `CoronaSun` with realistic colour by default or Kelvin/RGB, `CoronaMoon` with an RGB filter; intensity is Corona's multiplier, orientation is the emission direction (local −Z, verified by render). Families without a verified binding refuse the kind explicitly. Sky linking, size multiplier and moon phase stay at plugin defaults.

## Evidence

- Enum meanings come from Chaos's own `coronaConverter.ms` shipped with Corona 15 (`<Corona>\Scripts\`): units L3354, colorMode L3379, shape L3410–3546, bitmap enviroMapping L45–46, sun colorMode L3744–3746. Line refs are in the code comments.
- Shape geometry (width = X extent or radius, height = Y extent or cylinder length) confirmed from live bounding boxes per shape value.
- Emission direction confirmed by render: a rectangle lights the floor as created (local −Z) and goes dark when flipped 180°, so the shared matrix convention holds.

## Tested live (3ds Max 2027, Corona 15)

- `create_lights` with all four shapes in one transaction → `typed_readback_matched`; values cross-checked with MAXScript.
- `edit_lights`: output unit/value, RGB colour, size, enabled.
- Environment `existing_map` (scene CoronaSky) and `hdri` (CoronaBitmap) both bound and decoded; CoronaSky intensity edited with `sharing: all_instances` (the SHARED_RESOURCE guard fires correctly because the sky is also referenced by the render environment).

Happy to adjust naming or split this further if you prefer smaller PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpScb92JbsP9YUat1SpCny